### PR TITLE
fix: add migration for users without JTI

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,8 @@
 AllCops:
   TargetRubyVersion: 3.1.2
   Exclude:
-    - 'db/**/*'
+    - 'db/migrate/*'
+    - 'db/schema.rb'
     - 'bin/*'
     - 'vendor/**/*'
   SuggestExtensions: false

--- a/db/migrate/20240712140039_initialize_jti_for_existing_users.rb
+++ b/db/migrate/20240712140039_initialize_jti_for_existing_users.rb
@@ -1,0 +1,9 @@
+class InitializeJtiForExistingUsers < ActiveRecord::Migration[7.0]
+  def change
+    # Since we already have user records, we will need to initialize its `jti` column before setting it to not nullable.
+    change_column_null :users, :jti, true
+
+    User.all.each { |user| user.update_column(:jti, SecureRandom.uuid) }
+    change_column_null :users, :jti, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_07_03_150432) do
+ActiveRecord::Schema[7.0].define(version: 2024_07_12_140039) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -58,11 +58,6 @@ ActiveRecord::Schema[7.0].define(version: 2024_07_03_150432) do
     t.boolean "flexible", default: false
     t.index ["couch_id"], name: "index_bookings_on_couch_id"
     t.index ["user_id"], name: "index_bookings_on_user_id"
-  end
-
-  create_table "businesses", force: :cascade do |t|
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
   end
 
   create_table "characteristics", force: :cascade do |t|
@@ -139,9 +134,9 @@ ActiveRecord::Schema[7.0].define(version: 2024_07_03_150432) do
   create_table "reviews", force: :cascade do |t|
     t.text "content"
     t.integer "rating"
-    t.bigint "booking_id"
-    t.bigint "couch_id"
-    t.bigint "user_id"
+    t.bigint "booking_id", null: false
+    t.bigint "couch_id", null: false
+    t.bigint "user_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["booking_id"], name: "index_reviews_on_booking_id"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -84,8 +84,8 @@ smoking_allowed.save!
 puts "#{Facility.count} facilities created!"
 
 # Create a base user to get started with the app. Use the email and password from the .env file!
-user_email = ENV['BASE_USER_EMAIL']
-user_password = ENV['BASE_USER_PASSWORD']
+user_email = ENV.fetch('BASE_USER_EMAIL', nil)
+user_password = ENV.fetch('BASE_USER_PASSWORD', nil)
 puts 'Create first user'
 User.destroy_all
 base_user = User.new(


### PR DESCRIPTION
# Description

I had an issue locally where the JTI did not exist in a user. I don't know why the migration worked in the first place! This should fix it.

@lisbethpurrucker I don't know if there's a way to fix/remove a migration. If there's one that's safe, I'm happy to do that instead.

