### PR TITLE
fix: add data-turbo:false to session calls to display flash message

### DIFF
--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -3,7 +3,7 @@
     <h2 class="signin__title">Forgot your password?</h2>
 
     <div class="signin__form">
-      <%= simple_form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
+      <%= simple_form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post, 'data-turbo': 'false' }) do |f| %>
       <%= f.error_notification %>
 
       <div class="">

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -3,7 +3,7 @@
     <h2 class="signin__title">Quouch</h2>
     <h3 class="signin__subtitle">Welcome back!</h3>
     <div class="signin__form">
-      <%= simple_form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
+      <%= simple_form_for(resource, as: resource_name, html: { 'data-turbo': 'false' }, url: session_path(resource_name)) do |f| %>
           <%= f.input :email,
                       required: false,
                       label: false,

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -106,7 +106,7 @@
 						<p class="collapsible__subtitle">Session</p>
             <li>
               <i class="quouch-logout color-secondary" aria-label='Logout Icon'></i>
-							<%= button_to 'Logout', destroy_user_session_path, method: :delete, class: 'collapsible__logout' %>
+							<%= button_to 'Logout', destroy_user_session_path, method: :delete, 'data-turbo': 'false', class: 'collapsible__logout' %>
 						</li>
 					</ul>
 				</div>


### PR DESCRIPTION
# Description

Fixes the issue with flash messages not being shown properly in the following cases:

- when you enter a wrong password on log in, it adds a “invalid email or password” as random text, with every click it adds it again and again. if you then actually log in successfully, it stays on the page.
- when you log out, it should display a flash “successfully logged out” and it displays nothing
- when you click on forgot password? and you request an email to reset the password, the email is sent but no flash is displayed/no redirect happens. it throws a POST 500 error for turbo


This is the only fix I found, based on [this StackOverflow post](https://stackoverflow.com/questions/36214082/rails-devise-nil-location-provided-cant-build-uri-on-password-reset)