### PR TITLE
[#67] fix: repair interaction between characteristics and location filter

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -117,7 +117,11 @@ group :development, :test do
   gem 'bullet'
   gem 'byebug', platforms: %i[mri mingw x64_mingw]
   gem 'debug', platforms: %i[mri mingw x64_mingw]
+  gem 'guard'
+  gem 'guard-minitest'
+  gem 'minitest-reporters'
   gem 'rspec-rails'
+  gem 'shoulda', '~> 4.0'
   # Fake test data
   gem 'factory_bot_rails'
   gem 'faker', git: 'https://github.com/faker-ruby/faker.git', branch: 'main'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -94,6 +94,7 @@ GEM
       net-http-persistent
     amplitude-api (0.4.2)
       faraday (>= 1.0, < 3.0)
+    ansi (1.5.0)
     ast (2.4.2)
     autoprefixer-rails (10.4.16.0)
       execjs (~> 2)
@@ -185,9 +186,23 @@ GEM
       rake
     font-awesome-sass (6.5.2)
       sassc (~> 2.0)
+    formatador (1.1.0)
     geocoder (1.8.2)
     globalid (1.2.1)
       activesupport (>= 6.1)
+    guard (2.18.1)
+      formatador (>= 0.2.4)
+      listen (>= 2.7, < 4.0)
+      lumberjack (>= 1.0.12, < 2.0)
+      nenv (~> 0.1)
+      notiffany (~> 0.0)
+      pry (>= 0.13.0)
+      shellany (~> 0.0)
+      thor (>= 0.18.1)
+    guard-compat (1.2.1)
+    guard-minitest (2.4.6)
+      guard-compat (~> 1.2)
+      minitest (>= 3.0)
     http (5.2.0)
       addressable (~> 2.8)
       base64 (~> 0.1)
@@ -228,12 +243,16 @@ GEM
       kaminari-core (= 1.2.2)
     kaminari-core (1.2.2)
     language_server-protocol (3.17.0.3)
+    listen (3.9.0)
+      rb-fsevent (~> 0.10, >= 0.10.3)
+      rb-inotify (~> 0.9, >= 0.9.10)
     llhttp-ffi (0.5.0)
       ffi-compiler (~> 1.0)
       rake (~> 13.0)
     loofah (2.22.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
+    lumberjack (1.2.10)
     mail (2.8.1)
       mini_mime (>= 0.1.1)
       net-imap
@@ -247,6 +266,11 @@ GEM
     method_source (1.0.0)
     mini_mime (1.1.5)
     minitest (5.22.3)
+    minitest-reporters (1.7.1)
+      ansi
+      builder
+      minitest (>= 5.0)
+      ruby-progressbar
     monetize (1.13.0)
       money (~> 6.12)
     money (6.19.0)
@@ -258,6 +282,7 @@ GEM
       railties (>= 3.0)
     msgpack (1.7.2)
     multipart-post (2.4.0)
+    nenv (0.3.0)
     nested_form (0.3.2)
     net-http (0.4.1)
       uri
@@ -280,6 +305,9 @@ GEM
     noticed (1.6.3)
       http (>= 4.0.0)
       rails (>= 5.2.0)
+    notiffany (0.1.3)
+      nenv (~> 0.1)
+      shellany (~> 0.0)
     orm_adapter (0.5.0)
     pagy (6.0.4)
     parallel (1.24.0)
@@ -343,6 +371,9 @@ GEM
       zeitwerk (~> 2.5)
     rainbow (3.1.1)
     rake (13.2.1)
+    rb-fsevent (0.11.2)
+    rb-inotify (0.11.1)
+      ffi (~> 1.0)
     rdoc (6.6.3.1)
       psych (>= 4.0.0)
     redis (4.8.1)
@@ -405,6 +436,13 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
+    shellany (0.0.1)
+    shoulda (4.0.0)
+      shoulda-context (~> 2.0)
+      shoulda-matchers (~> 4.0)
+    shoulda-context (2.0.0)
+    shoulda-matchers (4.5.1)
+      activesupport (>= 4.2.0)
     simplecov (0.22.0)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
@@ -489,10 +527,13 @@ DEPENDENCIES
   faker!
   font-awesome-sass (~> 6.1)
   geocoder
+  guard
+  guard-minitest
   importmap-rails (~> 1.2.3)
   jbuilder
   jsonapi-serializer
   mail_form
+  minitest-reporters
   money-rails (~> 1.12)
   noticed (~> 1.6)
   pagy
@@ -510,6 +551,7 @@ DEPENDENCIES
   rubocop-rails
   sassc-rails
   selenium-webdriver
+  shoulda (~> 4.0)
   simple_form!
   simplecov
   sprockets-rails

--- a/Guardfile
+++ b/Guardfile
@@ -1,0 +1,42 @@
+# A sample Guardfile
+# More info at https://github.com/guard/guard#readme
+
+## Uncomment and set this to only include directories you want to watch
+# directories %w(app lib config test spec features) \
+#  .select{|d| Dir.exist?(d) ? d : UI.warning("Directory #{d} does not exist")}
+
+## Note: if you are using the `directories` clause above and you are not
+## watching the project directory ('.'), then you will want to move
+## the Guardfile to a watched dir and symlink it back, e.g.
+#
+#  $ mkdir config
+#  $ mv Guardfile config/
+#  $ ln -s config/Guardfile .
+#
+# and, you'll have to watch "config/Guardfile" instead of "Guardfile"
+
+guard :minitest, spring: 'bin/rails test' do
+  # with Minitest::Unit
+  watch(%r{^test/(.*)/?test_(.*)\.rb$})
+  watch(%r{^lib/(.*/)?([^/]+)\.rb$})     { |m| "test/#{m[1]}test_#{m[2]}.rb" }
+  watch(%r{^test/test_helper\.rb$})      { 'test' }
+
+  # with Minitest::Spec
+  # watch(%r{^spec/(.*)_spec\.rb$})
+  # watch(%r{^lib/(.+)\.rb$})         { |m| "spec/#{m[1]}_spec.rb" }
+  # watch(%r{^spec/spec_helper\.rb$}) { 'spec' }
+
+  # Rails 4
+  # watch(%r{^app/(.+)\.rb$})                               { |m| "test/#{m[1]}_test.rb" }
+  # watch(%r{^app/controllers/application_controller\.rb$}) { 'test/controllers' }
+  # watch(%r{^app/controllers/(.+)_controller\.rb$})        { |m| "test/integration/#{m[1]}_test.rb" }
+  # watch(%r{^app/views/(.+)_mailer/.+})                    { |m| "test/mailers/#{m[1]}_mailer_test.rb" }
+  # watch(%r{^lib/(.+)\.rb$})                               { |m| "test/lib/#{m[1]}_test.rb" }
+  # watch(%r{^test/.+_test\.rb$})
+  # watch(%r{^test/test_helper\.rb$}) { 'test' }
+
+  # Rails < 4
+  # watch(%r{^app/controllers/(.*)\.rb$}) { |m| "test/functional/#{m[1]}_test.rb" }
+  # watch(%r{^app/helpers/(.*)\.rb$})     { |m| "test/helpers/#{m[1]}_test.rb" }
+  # watch(%r{^app/models/(.*)\.rb$})      { |m| "test/unit/#{m[1]}_test.rb" }
+end

--- a/app/controllers/concerns/couches_concern.rb
+++ b/app/controllers/concerns/couches_concern.rb
@@ -17,9 +17,9 @@ module CouchesConcern
                              .where.not(user: { first_name: nil, city: nil, country: nil })
                              .order('RANDOM()')
 
+    apply_search_filter if params[:query].present?
     apply_characteristics_filter if params[:characteristics].present?
     apply_offers_filter if params.keys.any? { |key| key.to_s.include?('offers') }
-    apply_search_filter if params[:query].present?
 
     items = params[:items] || 9
 

--- a/app/controllers/concerns/couches_concern.rb
+++ b/app/controllers/concerns/couches_concern.rb
@@ -17,9 +17,9 @@ module CouchesConcern
                              .where.not(user: { first_name: nil, city: nil, country: nil })
                              .order('RANDOM()')
 
-    apply_search_filter if params[:query].present?
     apply_characteristics_filter if params[:characteristics].present?
-    apply_offers_filter if params.keys.any? { |key| key.include?('offers') }
+    apply_offers_filter if params.keys.any? { |key| key.to_s.include?('offers') }
+    apply_search_filter if params[:query].present?
 
     items = params[:items] || 9
 
@@ -29,7 +29,8 @@ module CouchesConcern
   private
 
   def apply_search_filter
-    @shuffled_couches = @shuffled_couches.search(params[:query])
+    @shuffled_couches = @shuffled_couches.search_by_location(params[:query])
+                                         .group("couches.id, #{PgSearch::Configuration.alias('couches')}.rank")
   end
 
   def apply_characteristics_filter

--- a/app/controllers/concerns/couches_concern.rb
+++ b/app/controllers/concerns/couches_concern.rb
@@ -30,7 +30,9 @@ module CouchesConcern
 
   def apply_search_filter
     @shuffled_couches = @shuffled_couches.search_by_location(params[:query])
-                                         .group("couches.id, #{PgSearch::Configuration.alias('couches')}.rank")
+                                         # use .reorder to eliminate the order by ranking that pg_search creates.
+                                         # The pg_search.rank ordering conflicts with the `group` and `having` clauses introduced by the characteristics filter
+                                         .reorder('RANDOM()')
   end
 
   def apply_characteristics_filter

--- a/app/models/couch.rb
+++ b/app/models/couch.rb
@@ -12,7 +12,7 @@ class Couch < ApplicationRecord
 
   scope :active, -> { joins(:user).where(users: { offers_couch: true }) }
 
-  pg_search_scope :search,
+  pg_search_scope :search_by_location,
                   associated_against: {
                     user: %i[
                       city

--- a/test/controllers/couches_concern_test.rb
+++ b/test/controllers/couches_concern_test.rb
@@ -1,15 +1,14 @@
 # frozen_string_literal: true
 
-require 'minitest/autorun'
 require 'test_helper'
 
 class CouchesConcernTest < ActiveSupport::TestCase
   include CouchesConcern
 
   setup do
-    # Create necessary test data
+    # Create the current user
     @user = FactoryBot.create(:test_user)
-    @couch = Couch.create!(user: @user) # Add necessary attributes
+    Couch.create!(user: @user)
   end
 
   test 'should get index' do
@@ -17,25 +16,292 @@ class CouchesConcernTest < ActiveSupport::TestCase
     assert_not_nil @couches
   end
 
-  test 'should apply search filter' do
-    # Set up necessary conditions for the search filter
-    params[:query] = 'test'
+  test 'should not find the current user' do
     index
+    assert_equal 0, @couches.length
+  end
+
+  test 'should return no results if city is not found' do
+    # Create at least one couch
+    @host = FactoryBot.create(:test_user)
+    @couch = Couch.create!(user: @host)
+
+    # Filter for a city that doesn't exist
+    params[:query] = 'Nonexistent City'
+    index
+
     # Add assertions to check that the search filter was applied correctly
+    assert_equal 0, @couches.length
+  end
+
+  test 'should search by city' do
+    # Create at least one couch
+    @host = FactoryBot.create(:test_user)
+    @couch = Couch.create!(user: @host)
+
+    # Filter by city
+    city = @host[:city]
+    params[:query] = city
+    index
+
+    # Add assertions to check that the search filter was applied correctly
+    assert_equal @couches.length, 1
+    assert_equal @couches.first, @couch
+  end
+
+  test 'should search by country' do
+    # Create at least one couch
+    @host = FactoryBot.create(:test_user)
+    @host.country = 'Canada'
+    @host.save!
+    @couch = Couch.create!(user: @host)
+
+    # Filter by city
+    params[:query] = 'Canada'
+    index
+
+    # Add assertions to check that the search filter was applied correctly
+    assert_equal @couches.length, 1
+    assert_equal @couches.first, @couch
   end
 
   test 'should apply characteristics filter' do
+    # Create two couches
+    @host = FactoryBot.create(:test_user)
+    @couch = Couch.create!(user: @host)
+
+    @host2 = FactoryBot.create(:test_user)
+    Couch.create!(user: @host2)
+
+    # Create a characteristic and assign it to only one host
+    characteristic1 = Characteristic.create!(name: 'Char1')
+    characteristic2 = Characteristic.create!(name: 'Char2')
+    @host.user_characteristics.create!(characteristic: characteristic1)
+    @host2.user_characteristics.create!(characteristic: characteristic2)
+
+    # Check that the characteristics filter is not applied when no characteristics are selected
+    index
+    assert_equal 2, @couches.length, 2
+
     # Set up necessary conditions for the characteristics filter
-    params[:characteristics] = [characteristics(:one).id] # Assuming you have fixtures set up
+    params[:characteristics] = [characteristic2.id]
     index
     # Add assertions to check that the characteristics filter was applied correctly
+    assert_equal 1, @couches.length
+    assert_equal [@host2.couch], @couches
+
+    puts @couches.to_json
   end
 
-  test 'should apply offers filter' do
+  test 'should apply multiple characteristics filter' do
+    # Create two couches
+    @host = FactoryBot.create(:test_user)
+    @couch = Couch.create!(user: @host)
+
+    @host2 = FactoryBot.create(:test_user)
+    Couch.create!(user: @host2)
+
+    # Create a characteristic and assign it to only one host
+    characteristic1 = Characteristic.create!(name: 'Char1')
+    characteristic2 = Characteristic.create!(name: 'Char2')
+    @host.user_characteristics.create!(characteristic: characteristic1)
+    @host.user_characteristics.create!(characteristic: characteristic2)
+    @host2.user_characteristics.create!(characteristic: characteristic2)
+
+    # Set up necessary conditions for the characteristics filter
+    params[:characteristics] = [characteristic1.id, characteristic2.id]
+    index
+    # Add assertions to check that the characteristics filter was applied correctly
+    assert_equal 1, @couches.length
+    assert_equal [@host.couch], @couches
+  end
+
+  test 'should only return couches that offer hang out' do
+    # Create two couches
+    @host = FactoryBot.create(:test_user)
+    @host.offers_hang_out = true
+    @host.save!
+    Couch.create!(user: @host)
+
+    @host2 = FactoryBot.create(:test_user)
+    @host2.offers_hang_out = false
+    @host2.save!
+    Couch.create!(user: @host2)
+
     # Set up necessary conditions for the offers filter
     params[:offers_hang_out] = true
     index
+
     # Add assertions to check that the offers filter was applied correctly
+    assert_equal 1, @couches.length
+    assert_equal [@host.couch], @couches
+  end
+
+  test 'should only return couches that offer co work' do
+    # Create two couches
+    @host = FactoryBot.create(:test_user)
+    @host.offers_co_work = false
+    @host.save!
+    @couch = Couch.create!(user: @host)
+
+    @host2 = FactoryBot.create(:test_user)
+    @host2.offers_co_work = false
+    @host2.save!
+    Couch.create!(user: @host2)
+
+    # Set up necessary conditions for the offers filter
+    params[:offers_hang_out] = true
+    index
+
+    # Add assertions to check that the offers filter was applied correctly
+    assert_equal 0, @couches.length
+  end
+
+  test 'should only return couches that offer a couch' do
+    # Create two couches
+    @host = FactoryBot.create(:test_user)
+    @host.offers_couch = true
+    @host.save!
+    Couch.create!(user: @host)
+
+    @host2 = FactoryBot.create(:test_user)
+    @host2.offers_couch = false
+    @host2.save!
+    Couch.create!(user: @host2)
+
+    # Set up necessary conditions for the offers filter
+    params[:offers_couch] = true
+    index
+
+    # Add assertions to check that the offers filter was applied correctly
+    assert_equal 1, @couches.length
+    assert_equal [@host.couch], @couches
+  end
+
+  test 'should combine offer and query filter' do
+    # Create two couches
+    @host = FactoryBot.create(:test_user)
+    @host.offers_couch = true
+    @host.city = 'Test City'
+    @host.save!
+    Couch.create!(user: @host)
+
+    @host2 = FactoryBot.create(:test_user)
+    @host2.offers_couch = true
+    @host2.city = 'Another City'
+    @host2.save!
+    Couch.create!(user: @host2)
+
+    # Set up necessary conditions for the offers filter
+    params[:offers_couch] = true
+    params[:query] = 'Test City'
+    index
+
+    # Add assertions to check that the offers filter was applied correctly
+    assert_equal 1, @couches.length
+    assert_equal [@host.couch], @couches
+  end
+
+  test 'should combine characteristic and offer filters' do
+    # Create three couches
+    @host = FactoryBot.create(:test_user)
+    @host.offers_couch = true
+    @host.save!
+    Couch.create!(user: @host)
+
+    @host2 = FactoryBot.create(:test_user)
+    @host2.offers_couch = true
+    @host2.save!
+    Couch.create!(user: @host2)
+
+    @host3 = FactoryBot.create(:test_user)
+    @host3.offers_couch = false
+    @host3.save!
+    Couch.create!(user: @host3)
+
+    # Add characteristic to two hosts
+    characteristic = Characteristic.create!(name: 'Char1')
+    @host.user_characteristics.create!(characteristic:)
+    @host2.user_characteristics.create!(characteristic:)
+    @host3.user_characteristics.create!(characteristic:)
+
+    # Set up necessary conditions for the offers filter
+    params[:offers_couch] = true
+    params[:characteristics] = [characteristic.id]
+    index
+
+    # Add assertions to check that the offers filter was applied correctly
+    assert_equal 2, @couches.length
+    assert_same_elements [@host.couch, @host2.couch], @couches
+  end
+
+  test 'should combine characteristic and query filters' do
+    # Create three couches
+    @host = FactoryBot.create(:test_user)
+    @host.city = 'Test City'
+    @host.save!
+    Couch.create!(user: @host)
+
+    @host2 = FactoryBot.create(:test_user)
+    @host2.city = 'Another City'
+    @host2.save!
+    Couch.create!(user: @host2)
+
+    @host3 = FactoryBot.create(:test_user)
+    @host3.city = 'Test City'
+    @host3.save!
+    Couch.create!(user: @host3)
+
+    # Add characteristic to two hosts
+    characteristic = Characteristic.create!(name: 'Char1')
+    @host.user_characteristics.create!(characteristic:)
+    @host2.user_characteristics.create!(characteristic:)
+    @host3.user_characteristics.create!(characteristic:)
+
+    # Set up necessary conditions for the offers filter
+    params[:query] = 'Test City'
+    params[:characteristics] = [characteristic.id]
+    index
+
+    # Add assertions to check that the offers filter was applied correctly
+    assert_equal 2, @couches.length
+    assert_same_elements [@host.couch, @host3.couch], @couches
+  end
+
+  test 'should combine three different filters' do
+    # Create three couches
+    @host = FactoryBot.create(:test_user)
+    @host.offers_couch = true
+    @host.city = 'Test City'
+    @host.save!
+    @couch = Couch.create!(user: @host)
+
+    @host2 = FactoryBot.create(:test_user)
+    @host2.offers_couch = true
+    @host2.city = 'Another City'
+    @host2.save!
+    Couch.create!(user: @host2)
+
+    @host3 = FactoryBot.create(:test_user)
+    @host3.offers_couch = false
+    @host3.city = 'Test City'
+    @host3.save!
+    Couch.create!(user: @host3)
+
+    # Add characteristic to two hosts
+    characteristic = Characteristic.create!(name: 'Char2')
+    @host.user_characteristics.create!(characteristic:)
+    @host3.user_characteristics.create!(characteristic:)
+
+    # Set up necessary conditions for the offers filter
+    params[:offers_couch] = true
+    params[:query] = 'Test City'
+    params[:characteristics] = [characteristic.id]
+    index
+
+    # Add assertions to check that the offers filter was applied correctly
+    assert_equal 1, @couches.length
+    assert_equal [@couch], @couches
   end
 
   private

--- a/test/controllers/couches_concern_test.rb
+++ b/test/controllers/couches_concern_test.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require 'minitest/autorun'
+require 'test_helper'
+
+class CouchesConcernTest < ActiveSupport::TestCase
+  include CouchesConcern
+
+  setup do
+    # Create necessary test data
+    @user = FactoryBot.create(:test_user)
+    @couch = Couch.create!(user: @user) # Add necessary attributes
+  end
+
+  test 'should get index' do
+    index
+    assert_not_nil @couches
+  end
+
+  test 'should apply search filter' do
+    # Set up necessary conditions for the search filter
+    params[:query] = 'test'
+    index
+    # Add assertions to check that the search filter was applied correctly
+  end
+
+  test 'should apply characteristics filter' do
+    # Set up necessary conditions for the characteristics filter
+    params[:characteristics] = [characteristics(:one).id] # Assuming you have fixtures set up
+    index
+    # Add assertions to check that the characteristics filter was applied correctly
+  end
+
+  test 'should apply offers filter' do
+    # Set up necessary conditions for the offers filter
+    params[:offers_hang_out] = true
+    index
+    # Add assertions to check that the offers filter was applied correctly
+  end
+
+  private
+
+  def params
+    @params ||= {}
+  end
+
+  def session
+    @session ||= {}
+  end
+
+  def current_user
+    @user
+  end
+end

--- a/test/controllers/couches_concern_test.rb
+++ b/test/controllers/couches_concern_test.rb
@@ -304,7 +304,66 @@ class CouchesConcernTest < ActiveSupport::TestCase
     assert_equal [@couch], @couches
   end
 
+  test 'pagination should work' do
+    setup_with_pagination
+
+    index
+
+    # Add assertions to check that the offers filter was applied correctly
+    assert_equal 5, @couches.length
+    assert_equal 10, @pagy.count
+    first_page = @couches
+
+    # Navigate to next page
+    params[:page] = 2
+    index
+
+    # Add assertions to check that the pagination works
+    assert_equal 5, @couches.length
+    assert_not_same @couches, first_page
+  end
+
+  test 'pagination should work with filters' do
+    setup_with_pagination
+
+    # Change the city for 5+ users
+    User.last(7).each do |user|
+      user.city = 'Test City'
+      user.save!
+    end
+
+    assert_equal 7, User.where(city: 'Test City').count
+
+    # Filter by city
+    params[:query] = 'Test City'
+    index
+
+    # Add assertions to check that the offers filter was applied correctly
+    assert_equal 5, @couches.length
+    assert_equal 7, @pagy.count
+    first_page = @couches
+
+    # Navigate to next page
+    params[:page] = 2
+    index
+
+    # Add assertions to check that the pagination works
+    assert_equal 2, @couches.length
+    assert_not_same @couches, first_page
+  end
+
   private
+
+  def setup_with_pagination
+    # Create 10 couches
+    10.times do
+      host = FactoryBot.create(:test_user)
+      Couch.create!(user: host)
+    end
+
+    # Set up necessary conditions for the offers filter
+    params[:items] = 5
+  end
 
   def params
     @params ||= {}

--- a/test/factories/users.rb
+++ b/test/factories/users.rb
@@ -41,6 +41,10 @@ FactoryBot.define do
     end
 
     factory :test_user, class: User do
+      offers_co_work { false }
+      offers_hang_out { false }
+      travelling { false }
+
       after(:build) do |user|
         file = URI.parse(Faker::Avatar.image).open
         user.photo.attach(io: file, filename: 'avatar.png', content_type: 'image/png')

--- a/test/factories/users.rb
+++ b/test/factories/users.rb
@@ -22,18 +22,18 @@ FactoryBot.define do
 
     user_characteristics { build_list(:user_characteristic, 3) }
 
+    after(:build) do |user|
+      file = URI.parse(Faker::Avatar.image).open
+      user.photo.attach(io: file, filename: 'avatar.png', content_type: 'image/png')
+
+      random_address = ADDRESSES.sample
+      user.address = random_address[:street]
+      user.zipcode = random_address[:zipcode]
+      user.city = random_address[:city]
+      user.country = random_address[:country]
+    end
+
     factory :random_user do
-      after(:build) do |user|
-        file = URI.parse(Faker::Avatar.image).open
-        user.photo.attach(io: file, filename: 'avatar.png', content_type: 'image/png')
-
-        random_address = ADDRESSES.sample
-        user.address = random_address[:street]
-        user.zipcode = random_address[:zipcode]
-        user.city = random_address[:city]
-        user.country = random_address[:country]
-      end
-
       after(:create) do |user|
         # Needed for the search to work: add a couch for the newly created user
         Couch.create!(user:)
@@ -44,16 +44,15 @@ FactoryBot.define do
       offers_co_work { false }
       offers_hang_out { false }
       travelling { false }
+    end
 
-      after(:build) do |user|
-        file = URI.parse(Faker::Avatar.image).open
-        user.photo.attach(io: file, filename: 'avatar.png', content_type: 'image/png')
+    factory :test_user_couch, class: User do
+      offers_co_work { false }
+      offers_hang_out { false }
+      travelling { false }
 
-        random_address = ADDRESSES.sample
-        user.address = random_address[:street]
-        user.zipcode = random_address[:zipcode]
-        user.city = random_address[:city]
-        user.country = random_address[:country]
+      after(:create) do |user|
+        Couch.create!(user:)
       end
     end
   end

--- a/test/helpers/sign_in_helper.rb
+++ b/test/helpers/sign_in_helper.rb
@@ -1,0 +1,6 @@
+module SignInHelper
+  def sign_in_as(user)
+    post user_session_path, params: { user: { email: user.email, password: user.password } }
+    follow_redirect!
+  end
+end

--- a/test/helpers/user_helper.rb
+++ b/test/helpers/user_helper.rb
@@ -1,0 +1,7 @@
+module UserHelper
+  def create_user_with(email:, password:)
+    @user = FactoryBot.build(:test_user_couch, email:, password:)
+    @user.save!
+    @user
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -28,3 +28,19 @@ module ActiveSupport
     end
   end
 end
+
+require_relative 'helpers/sign_in_helper'
+require_relative 'helpers/user_helper'
+
+module ActiveSupport
+  class TestCase
+    include UserHelper
+  end
+end
+
+module ActionDispatch
+  class IntegrationTest
+    include SignInHelper
+    include UserHelper
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,6 +2,10 @@ ENV['RAILS_ENV'] ||= 'test'
 require_relative '../config/environment'
 require 'rails/test_help'
 require 'faker'
+require 'minitest/autorun'
+require 'minitest/reporters'
+
+Minitest::Reporters.use! Minitest::Reporters::SpecReporter.new unless ENV['RM_INFO']
 
 Faker::Config.random = Random.new
 


### PR DESCRIPTION
Issue number: resolves #67 

---------

### Description
The interaction between characteristic and location filtering was failing. The problem seems to be that `pg_search` introduces a clause to order by rank, and the `group` and `having` clause wanted this column to be referenced in a group. When adding this column to a group, it caused the results to be aggregated, breaking the pagination.
The solution I found required removing the ranking from the `search_by_location` method. We can discuss if this is something that we need and how we can improve our filtering!

## Other changes
- Add tests for filtering couches
- Add `guard` gem to better run tests locally (watch functionality)
- Add [`shoulda`](https://github.com/thoughtbot/shoulda) for added test assertions

### Checklist
- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Rubocop passes
- [x] Extended the README / documentation, if necessary
