### PR TITLE
fix: move from start to flex-start

### DIFF
--- a/app/assets/stylesheets/components/_booking-form.scss
+++ b/app/assets/stylesheets/components/_booking-form.scss
@@ -36,7 +36,7 @@
             display: flex;
             flex-direction: column;
             color: $gray-05;
-            align-items: start;
+            align-items: flex-start;
             margin: 1rem auto;
             width: fit-content;
 

--- a/app/assets/stylesheets/components/_bookings.scss
+++ b/app/assets/stylesheets/components/_bookings.scss
@@ -41,7 +41,7 @@
 
     @media (min-width: $break-small) {
         display: flex;
-        justify-content: start;
+        justify-content: flex-start;
     }
 
     &__profile {

--- a/app/assets/stylesheets/components/_chat.scss
+++ b/app/assets/stylesheets/components/_chat.scss
@@ -114,11 +114,11 @@
         }
 
         &--left {
-            justify-content: start;
+            justify-content: flex-start;
         }
 
         &--right {
-            justify-content: end;
+            justify-content: flex-end;
         }
     }
 

--- a/app/assets/stylesheets/components/_host.scss
+++ b/app/assets/stylesheets/components/_host.scss
@@ -86,7 +86,7 @@
 
         @media (min-width: $break-x-large) {
             flex-wrap: nowrap;
-            justify-content: start;
+            justify-content: flex-start;
         }
     }
 

--- a/app/assets/stylesheets/components/_plans.scss
+++ b/app/assets/stylesheets/components/_plans.scss
@@ -99,7 +99,7 @@
         @include feature-tag;
 
         display: flex;
-        align-items: start;
+        align-items: flex-start;
         gap: .5rem;
         margin-top: auto;
         margin-bottom: 0;

--- a/app/assets/stylesheets/components/_requests.scss
+++ b/app/assets/stylesheets/components/_requests.scss
@@ -26,7 +26,7 @@
     @media (min-width: $break-small) {
         display: flex;
         max-height: fit-content;
-        justify-content: start;
+        justify-content: flex-start;
     }
 
     &__profile {

--- a/app/assets/stylesheets/components/_user-form.scss
+++ b/app/assets/stylesheets/components/_user-form.scss
@@ -44,7 +44,7 @@
 
 		> label { margin: 1rem auto; }
 
-		@media (min-width: $break-medium) { align-items: start; }
+		@media (min-width: $break-medium) { align-items: flex-start; }
 
 		&-preview {
 			display: inline-block;

--- a/app/assets/stylesheets/pages/_home.scss
+++ b/app/assets/stylesheets/pages/_home.scss
@@ -291,7 +291,7 @@
 
             &-item {
                 display: flex;
-                align-items: start;
+                align-items: flex-start;
                 gap: .3rem;
 
                 i {

--- a/app/assets/stylesheets/partials/_errors.scss
+++ b/app/assets/stylesheets/partials/_errors.scss
@@ -1,7 +1,7 @@
 .form-error {
     color: $error;
     display: flex;
-    align-items: start;
+    align-items: flex-start;
     gap: .2rem;
     font-size: .75rem;
     margin-left: .5rem;

--- a/app/assets/stylesheets/partials/_footer.scss
+++ b/app/assets/stylesheets/partials/_footer.scss
@@ -58,7 +58,7 @@
 			a { color: $gray-05; }
 			a:hover { opacity: .8; }
 
-			@media (min-width: $break-medium) { justify-content: start; }
+			@media (min-width: $break-medium) { justify-content: flex-start; }
 		}
 	}
 


### PR DESCRIPTION
### Description
There's a bunch of warnings from the CSS compilation run about using `flex-start` instead of `start` due to mixed support.

Error: `start value has mixed support, consider using flex-start instead`

### Checklist
- [x] Code compiles correctly
