### PR TITLE
feat: add GDPR cookie banner [#92]

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,9 +54,6 @@ gem 'geocoder'
 # Use Redis adapter to run Action Cable in production
 gem 'redis', '~> 4.0'
 
-# Debugging
-gem 'pry-byebug'
-
 # Use Kredis to get higher-level data types in Redis [https://github.com/rails/kredis]
 # gem 'kredis'
 
@@ -112,11 +109,17 @@ gem 'amplitude-api'
 # Importmap for JS modules
 gem 'importmap-rails', '~> 1.2.3'
 
+# GDPR gem https://github.com/infinum/cookies_eu
+gem 'cookies_eu'
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem 'bullet'
+  # Debugging
   gem 'byebug', platforms: %i[mri mingw x64_mingw]
   gem 'debug', platforms: %i[mri mingw x64_mingw]
+  gem 'pry-byebug'
+  # Test
   gem 'guard'
   gem 'guard-minitest'
   gem 'minitest-reporters'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -130,6 +130,8 @@ GEM
     coderay (1.1.3)
     concurrent-ruby (1.3.4)
     connection_pool (2.4.1)
+    cookies_eu (1.7.8)
+      js_cookie_rails (~> 2.2.0)
     countries (6.0.0)
       unaccent (~> 0.3)
     crass (1.0.6)
@@ -225,6 +227,8 @@ GEM
     jbuilder (2.11.5)
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
+    js_cookie_rails (2.2.0)
+      railties (>= 3.1)
     json (2.7.2)
     jsonapi-serializer (2.2.0)
       activesupport (>= 4.2)
@@ -520,6 +524,7 @@ DEPENDENCIES
   byebug
   capybara
   cloudinary
+  cookies_eu
   countries
   debug
   devise

--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -6,3 +6,4 @@
 //= link application.js
 //= link QuouchIcons.css
 //= link_tree ../../../vendor/q-icons/font
+//= link cookies_eu

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -49,5 +49,6 @@
 
 @import 'pages/about';
 @import 'pages/contact';
+@import 'pages/cookies';
 @import 'pages/home';
 @import 'pages/general';

--- a/app/assets/stylesheets/pages/_cookies.scss
+++ b/app/assets/stylesheets/pages/_cookies.scss
@@ -1,7 +1,16 @@
+// External libraries
+@import 'cookies_eu';
+
 .cookies {
     .general__numbered-list {
         li {
             font-size: smaller;
         }
+    }
+}
+
+.cookies-eu {
+    .cookies-eu-ok {
+        background-color: $primary !important;
     }
 }

--- a/app/assets/stylesheets/pages/_cookies.scss
+++ b/app/assets/stylesheets/pages/_cookies.scss
@@ -1,0 +1,7 @@
+.cookies {
+    .general__numbered-list {
+        li {
+            font-size: smaller;
+        }
+    }
+}

--- a/app/assets/stylesheets/pages/_cookies.scss
+++ b/app/assets/stylesheets/pages/_cookies.scss
@@ -12,5 +12,6 @@
 .cookies-eu {
     .cookies-eu-ok {
         background-color: $primary !important;
+        border-radius: 8px;
     }
 }

--- a/app/assets/stylesheets/pages/_general.scss
+++ b/app/assets/stylesheets/pages/_general.scss
@@ -22,7 +22,10 @@
 		margin-left: 2rem;
 	}
 
-	&__numbered-list { margin: 0 0 2rem 2rem; }
+	&__numbered-list {
+		margin: 0 0 2rem 2rem;
+		list-style: decimal !important;
+	}
 	
 	&__title {
 		@include title-3;

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,7 +1,7 @@
 require 'csv'
 
 class PagesController < ApplicationController
-  skip_before_action :authenticate_user!, only: %i[home about faq guidelines safety privacy impressum terms]
+  skip_before_action :authenticate_user!, only: %i[home about faq guidelines safety privacy impressum terms cookies]
   before_action :authenticate, only: [:emails]
 
   def emails

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -19,6 +19,7 @@
     <%= stylesheet_link_tag 'application', 'data-turbo-track': 'reload' %>
     <%= javascript_importmap_tags %>
     <%= javascript_include_tag 'application', 'data-turbo-track': 'reload', defer: true %>
+    <%= javascript_include_tag 'cookies_eu', 'data-turbo-track': 'reload', defer: true %>
 
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-GWGXEQSWDX"></script>
     <script>
@@ -63,6 +64,7 @@
 
     <%= yield %>
 
+    <%= render 'cookies_eu/consent_banner', link: '/cookies', target: '_blank' %>
     <%= render 'shared/footer' unless controller_name == 'chats' && action_name == 'show' %>
   </body>
 </html>

--- a/app/views/pages/cookies.html.erb
+++ b/app/views/pages/cookies.html.erb
@@ -1,0 +1,194 @@
+<section class="general">
+  <h1 class="general__header">Cookies</h1>
+  <div class="general__wrap cookies">
+    <p>
+      Cookies are small text files which are downloaded to your computer, tablet or mobile phone when you visit a
+      website
+      or application. The website or application may retrieve these cookies from your web browser (eg Internet Explorer,
+      Mozilla Firefox or Google Chrome) each time you visit, so they can recognise you, remember your preferences and
+      provide you with a more secure online experience.
+    </p>
+
+    <p>
+      Generally, cookies are very useful and are a common method used by almost every website you visit because they
+      help
+      to make your online experience as smooth as possible. For security reasons, many websites will not function at all
+      without the use of cookies (or other similar technologies, such as "web beacons" or "tags").
+    </p>
+    <p>
+      Cookies generally do not hold any information to identify an individual person, but are instead used to identify a
+      browser on an individual machine.
+    </p>
+    <p>
+      If you prefer, you can restrict, block or delete cookies by changing your browser settings but that may mean that
+      the website won't work properly
+    </p>
+    <p>
+      For more information about cookies and their impact on you and your browsing
+      visit <%= link_to 'www.aboutcookies.org', 'http://www.aboutcookies.org' %>.</p>
+    </p>
+
+    <h2 class="general__title">
+      Types of Cookies
+    </h2>
+
+    <h4>Necessary cookies</h4>
+    <p>
+      These cookies are essential in helping you to make use of the features and services we offer on the Quouch App
+      website. Without these cookies, the services you want to use cannot be provided. These cookies do not gather
+      information about you that could be used to identify you, and they do not monitor or remember where you have been
+      on the internet.
+    </p>
+    <h4>Functional cookies</h4>
+    <p>
+      These cookies allow us to provide you with a better online experience when you use our website. They do not
+      gather or store any information which would allow us to identify you personally.
+    </p>
+    <h4>Performance cookies</h4>
+    <p>
+      Performance cookies help us to understand how our customers use our site, so we can keep our products and
+      services relevant, easy to use and up to date. For example, we can see which products and services are most
+      popular, identify when and where errors occur, and test different versions of a page in order to provide an
+      improved online experience.
+    </p>
+    <p>
+      Sometimes, the services we use to collect this information may be operated by other companies on our behalf.
+      They may use similar technologies to cookies, known as "web beacons" or "tags". These are anonymous and, as
+      they are only used for statistical purposes, they do not contain or collect any information that identifies
+      you.
+    </p>
+    <h4>Targeting cookies</h4>
+    <p>
+      We have relationships with carefully selected and monitored suppliers (third parties) who may also set
+      cookies during your visit. The purpose of these cookies is "behavioural advertising" (also known as
+      "behavioural targeting" or "remarketing"), which is a means of showing you relevant products and
+      services based on what you appear to be interested in. Although these cookies can track your visits
+      around the web they don't know who you are. Without these cookies, online advertisements you encounter
+      will be less relevant to you and your interests.
+    </p>
+
+    <h2 class="general__title">Managing Cookies</h2>
+
+    <p>
+      Most internet browsers allow you to erase cookies from your computer hard drive, block all cookies
+      (or just third-party cookies) or warn you before a cookie is stored on your device.
+    </p>
+    <p>
+      Please note, if you choose to block all cookies, our site will not function as intended and you will
+      not be able to use or access many of the services we provide. If you have blocked all cookies and
+      wish to make full use of the features and services we offer, you will need to enable your cookies.
+      You can do this in your browser (see below).
+    </p>
+    <p>
+      Rather than blocking all cookies, you can choose to only block third-party cookies which will still allow our
+      website to function as intended.
+    </p>
+
+    <h4>How to manage cookies on your PC</h4>
+
+    <p>
+      To enable cookies on our website, follow the steps below.
+    </p>
+
+    <h5>Google Chrome</h5>
+    <ol class="general__numbered-list">
+      <li>
+        Click "Tools" at the top of your browser and select "Settings".
+      </li>
+      <li>
+        Click "Show advanced settings", scroll down to the section "Privacy" and click "Content Settings."
+      </li>
+      <li>
+        Select "Allow local data to be set". To only acept first-party cookies, check the box next to "Block all
+        third-party cookies without exception"
+      </li>
+    </ol>
+    <h5> Microsoft Internet Explorer 6.0, 7.0, 8.0, 9.0</h5>
+
+    <ol class="general__numbered-list">
+      <li>
+        Click "Tools" at the top of your browser and select "Internet Options", then click the "Privacy" tab.
+      </li>
+      <li>
+        Check that the level of your privacy is set to Medium or lower, which will allow the use of cookies in your
+        browser.
+      </li>
+      <li>
+        If set above medium level it will prevent the use of cookies.
+      </li>
+    </ol>
+
+    <h5>Mozilla Firefox</h5>
+
+    <ol class="general__numbered-list">
+      <li>
+        Click "Tools" at the top of your browser and select "Options".
+      </li>
+      <li>
+        Then select the "Privacy" icon.
+      </li>
+      <li>
+        Click the "Cookies" and select "Allow pages to create a cookie."
+      </li>
+    </ol>
+    <h5>Safari</h5>
+
+    <ol class="general__numbered-list">
+      <li>
+        Click the gear icon at the top of your browser and select "Settings".
+      </li>
+      <li>
+        Click the "Privacy" tab, then select the option "Disable the use of cookies by third parties and advertising
+        cookies."
+      </li>
+      <li>
+        Click "Save".
+      </li>
+    </ol>
+
+    <h4>How to manage cookies on your Mac</h4>
+    <p>
+      To enable cookies on our website, follow the steps below.
+    </p>
+
+
+    <h5>Safari on OSX</h5>
+    <ol class="general__numbered-list">
+      <li>
+        Click "Safari" on the top of your browser and select "Settings".
+      </li>
+      <li>
+        Click the "Privacy" and then "Enable cookies."
+      </li>
+      <li>
+        Select "only the pages you have visited."
+      </li>
+    </ol>
+    <h5>Mozilla and Netscape on OSX</h5>
+    <ol class="general__numbered-list">
+      <li>
+        Click "Mozilla" or "Netscape" at the top of your browser and select "Settings".
+      </li>
+      <li>
+        Scroll down to the "Cookies" under "Privacy & Security".
+      </li>
+      <li>
+        Select "Allow cookies only to the original site."
+      </li>
+    </ol>
+
+    <h5>Opera</h5>
+
+    <ol class="general__numbered-list">
+      <li>
+        Click "Menu" on the top of your browser and select "Settings".
+      </li>
+      <li>
+        Then select "Options" tab and the "Advanced".
+      </li>
+      <li>
+        Select "Enable cookies."
+      </li>
+    </ol>
+  </div>
+</section>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,7 @@ Rails.application.routes.draw do
   get 'privacy', to: 'pages#privacy'
   get 'safety', to: 'pages#safety'
   get 'terms', to: 'pages#terms'
+  get 'cookies', to: 'pages#cookies'
   get 'invite-code', to: 'invites#invite_code_form'
   get 'validate-invite-code', to: 'invites#validate_invite_code'
   get 'invite-friend', to: 'invites#invite_friend'

--- a/test/system/cookies_test.rb
+++ b/test/system/cookies_test.rb
@@ -1,0 +1,38 @@
+require 'system_test_helper'
+
+class CookiesTest < ApplicationSystemTestCase
+  test 'should have a cookies page' do
+    visit cookies_url
+
+    assert_selector 'h1', text: 'COOKIES'
+  end
+
+  test 'should see cookies banner' do
+    visit root_path
+    assert_selector '.cookies-eu', count: 1
+    assert_selector '.cookies-eu-content-holder', text: 'you agree to our use of cookies'
+    assert_selector '.cookies-eu-ok', text: 'OK'
+    assert_selector '.cookies-eu-link', text: 'Learn more'
+  end
+
+  test 'should navigate to cookies page' do
+    visit root_path
+
+    find('.cookies-eu-link').click
+    # Check that a new tab was opened and switch to it
+    assert_equal 2, page.driver.browser.window_handles.size
+    page.driver.browser.switch_to.window(page.driver.browser.window_handles.last)
+
+    assert_selector 'h1', text: 'COOKIES'
+  end
+
+  test 'should close cookies banner' do
+    visit root_path
+    find('.cookies-eu-ok').click
+    assert_no_selector '.cookies-eu'
+
+    # Check that the banner is not shown after refreshing the page
+    page.refresh
+    assert_no_selector '.cookies-eu'
+  end
+end


### PR DESCRIPTION
Issue number: resolves #92 

---------

### Description
Added a page for the Cookies text with some sample text.
Added the `cookies_eu` gem, which seems to work for getting the banner working.

## Other information
![image](https://github.com/user-attachments/assets/680c0081-3187-4363-86fe-1a5c9a2aba11)
![image](https://github.com/user-attachments/assets/db21d058-ec33-496b-b11c-57a41bbfe940)


### Checklist
- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Rubocop passes