### PR TITLE
hotfix: remove complex `unless` clause for validation

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -38,13 +38,12 @@ class User < ApplicationRecord # rubocop:disable Metrics/ClassLength
   validate :validate_age, on: :create
   validate :validate_travelling, on: :create
   validate :at_least_one_option_checked?, on: :create
-  validates :invited_by_id, on: :create, presence: { message: 'Please provide a valid invite code' },
-                            unless: -> { User.count.zero? }
+  validates :invited_by_id, on: :create, presence: { message: 'Please provide a valid invite code' }
 
   after_validation :create_stripe_reference, on: :create, unless: -> { Rails.env.test? }
 
   geocoded_by :address
-  after_validation :geocode, if: :will_save_change_to_address?, unless: -> { Rails.env.test? }
+  after_validation :geocode, if: :will_save_change_to_address?
   before_create :generate_invite_code
 
   pg_search_scope :search_city_or_country,

--- a/test/controllers/concerns/couches_concern_test.rb
+++ b/test/controllers/concerns/couches_concern_test.rb
@@ -6,7 +6,10 @@ class CouchesConcernTest < ActiveSupport::TestCase
   include CouchesConcern
 
   setup do
+    # Clean up the database to avoid conflicts but create a seed user without a couch to use the invite_code
     db_cleanup
+    create_seed_user
+
     # Create the current user
     @user = FactoryBot.create(:test_user_couch)
   end

--- a/test/controllers/concerns/registration_concern_test.rb
+++ b/test/controllers/concerns/registration_concern_test.rb
@@ -6,6 +6,8 @@ class RegistrationConcernTest < ActiveSupport::TestCase
   include RegistrationConcern
 
   setup do
+    create_seed_user
+
     @user = FactoryBot.create(:user)
   end
 

--- a/test/helpers/user_helper.rb
+++ b/test/helpers/user_helper.rb
@@ -5,4 +5,23 @@ module UserHelper
     Couch.create!(user: @user)
     @user
   end
+
+  def create_seed_user
+    random_address = ADDRESSES.sample
+
+    base_user = User.new(
+      email: Faker::Internet.email,
+      password: Faker::Internet.password,
+      first_name: Faker::Name.first_name,
+      last_name: Faker::Name.last_name,
+      confirmed_at: Time.now,
+      address: random_address[:street],
+      zipcode: random_address[:zipcode],
+      city: random_address[:city],
+      country: random_address[:country],
+      travelling: true
+    )
+
+    base_user.save!(validate: false)
+  end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -92,18 +92,7 @@ class UserTest < ActiveSupport::TestCase
     assert_not_nil @user.invite_code
   end
 
-  test 'should save first user without invite code' do
-    # Remove all users first
-    db_cleanup
-
-    assert_equal 0, User.count
-    @user.invited_by_id = nil
-    assert_equal true, @user.valid?
-  end
-
-  test 'should not save user without invite code when other users are present' do
-    assert_not_equal 0, User.count
-
+  test 'should not save user without invite code' do
     @user.invited_by_id = nil
     assert_not @user.valid?
     assert_equal @user.errors.messages[:invited_by_id], ['Please provide a valid invite code']

--- a/test/support/helpers/jwt_token_helper_test.rb
+++ b/test/support/helpers/jwt_token_helper_test.rb
@@ -3,6 +3,10 @@
 require 'test_helper'
 
 class JwtTokenHelperTest < ActionView::TestCase
+  setup do
+    create_seed_user
+  end
+
   test 'should raise error when no token is found' do
     # Check that the error is raised when no token is found
     error = assert_raises JwtError do

--- a/test/system/users/registration_workflow_test.rb
+++ b/test/system/users/registration_workflow_test.rb
@@ -71,6 +71,27 @@ class RegistrationWorkflowTest < ApplicationSystemTestCase
     assert_selector 'h1', text: 'Set account details'.upcase
 
     # Fill in the form
+    fill_in_form_data
+
+    click_on 'Create Account'
+
+    # Should be in the main page again and see success a message
+    assert_selector 'div.flash', text: 'A message with a confirmation link'
+    assert_current_path root_path
+
+    # Check that the user was created and has invited_by_id value set
+    user = User.last
+    assert_equal user[:email], @fake_user_data[:email]
+    assert_equal user[:invited_by_id], @inviting_user[:id]
+  end
+
+  private
+
+  def user_registration_path
+    "/users/sign_up?invite_code=#{@inviting_user[:invite_code]}"
+  end
+
+  def fill_in_form_data
     attach_file(@avatar.path) do
       find('div.input.file.user_photo').click
     end
@@ -102,22 +123,6 @@ class RegistrationWorkflowTest < ApplicationSystemTestCase
     password = Faker::Internet.password
     fill_in 'user[password]', with: password
     fill_in 'user[password_confirmation]', with: password
-
-    click_on 'Create Account'
-
-    # Should be in the main page again
-    assert_current_path root_path
-    assert_selector 'div.flash', text: 'A message with a confirmation link'
-
-    # Check that the user was created and has invited_by_id value set
-    user = User.last
-    assert_equal user[:email], @fake_user_data[:email]
-    assert_equal user[:invited_by_id], @inviting_user[:id]
   end
 
-  private
-
-  def user_registration_path
-    "/users/sign_up?invite_code=#{@inviting_user[:invite_code]}"
-  end
 end


### PR DESCRIPTION
### Description
Revert unless clause for validating `invited_by_id`, so that it's always checked.
Modify tests so they pass

### Checklist
- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Rubocop passes
- [x] Extended the README / documentation, if necessary
