### PR TITLE
fix: restore invited_by_id validation and add extra logging and error message

### DIFF
--- a/app/controllers/concerns/registration_concern.rb
+++ b/app/controllers/concerns/registration_concern.rb
@@ -62,7 +62,12 @@ module RegistrationConcern
     return unless params[:invite_code].present?
 
     @invited_by = User.find_by(invite_code: params[:invite_code].downcase)
-    puts "New user invited by: #{@invited_by.id}"
+    if @invited_by.nil?
+      puts "No user found with invite code: #{params[:invite_code]}"
+      return nil
+    end
+
+    puts "Found user with invite code: #{params[:invite_code]} -> #{@invited_by.email}"
     @invited_by.id
   end
 

--- a/app/controllers/concerns/registration_concern.rb
+++ b/app/controllers/concerns/registration_concern.rb
@@ -63,24 +63,22 @@ module RegistrationConcern
 
     @invited_by = User.find_by(invite_code: params[:invite_code].downcase)
     if @invited_by.nil?
-      puts "No user found with invite code: #{params[:invite_code]}"
+      Rails.logger.warn("No user found with invite code: #{params[:invite_code]}")
       return nil
     end
 
-    puts "Found user with invite code: #{params[:invite_code]} -> #{@invited_by.email}"
+    Rails.logger.info("Found user with invite code: #{params[:invite_code]} -> #{@invited_by.email}")
     @invited_by.id
   end
 
   def update_profile
     @user.update(country: beautify_country)
-    puts "Updated user profile with country: #{beautify_country}"
+    Rails.logger.info("Updated user profile with country: #{beautify_country}")
     create_couch if @user.couch.nil?
   end
 
   def beautify_country
     country = params[:user][:country]
-    translated_country = ISO3166::Country[country].translations[I18n.locale.to_s]
-    puts "Beautified country: #{country} -> #{translated_country}"
-    translated_country
+    ISO3166::Country[country].translations[I18n.locale.to_s]
   end
 end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -24,7 +24,10 @@ module Users
         end
         UserMailer.welcome_email(resource).deliver_later
       else
-        puts resource.errors.full_messages
+        if resource.errors[:invited_by_id].present?
+          flash[:error] = 'There seems to be an issue with your invite code. Please contact the Quouch team!'
+        end
+
         clean_up_passwords resource
         set_minimum_password_length
         respond_with resource

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -38,9 +38,7 @@ class User < ApplicationRecord # rubocop:disable Metrics/ClassLength
   validate :validate_age, on: :create
   validate :validate_travelling, on: :create
   validate :at_least_one_option_checked?, on: :create
-  # fixme: Restore this validation when we understand the problem with the invite code
-  # validates :invited_by_id, on: :create, presence: { message: 'Please provide a valid invite code' },
-  #                           unless: -> { User.count.zero? }
+  validates :invited_by_id, on: :create, presence: { message: 'Please provide a valid invite code' }
 
   after_validation :create_stripe_reference, on: :create, unless: -> { Rails.env.test? }
 

--- a/test/integration/controllers/users/registrations_controller_test.rb
+++ b/test/integration/controllers/users/registrations_controller_test.rb
@@ -28,8 +28,6 @@ module Users
     end
 
     test 'should not create a user without an invite code' do
-      # fixme: Restore this test when the invite code is required
-      skip
       # expect error message
       post user_registration_url,
            params: { user: @user_object,
@@ -39,8 +37,6 @@ module Users
     end
 
     test 'should not create a user with an invalid invite code' do
-      # fixme: Restore this test when the invite code is required
-      skip
       # expect error message
       post user_registration_url,
            params: { user: @user_object,
@@ -48,6 +44,21 @@ module Users
                      invite_code: 'invalid' }
 
       assert_response :unprocessable_entity
+    end
+
+    test 'should send a flash message if there is an issue with the invite code' do
+      inviting_user = FactoryBot.create(:test_user)
+      # Make the invite code invalid
+      inviting_user.invite_code = 'ABC123'
+      inviting_user.save
+
+      # expect error message
+      post user_registration_url,
+           params: { user: @user_object,
+                     user_characteristic: { characteristic_ids: [Characteristic.first.id] },
+                     invite_code: inviting_user[:invite_code] }
+
+      assert_includes flash[:error], 'There seems to be an issue with your invite code.'
     end
 
     test 'should create a user with an invite code' do

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -93,8 +93,6 @@ class UserTest < ActiveSupport::TestCase
   end
 
   test 'should not save user without invite code' do
-    skip 'This test is disabled because the user is not required to have an invite code yet'
-    # fixme: Restore this test when the invite code is required
     @user.invited_by_id = nil
     assert_not @user.valid?
     assert_equal @user.errors.messages[:invited_by_id], ['Please provide a valid invite code']

--- a/test/system/users/registration_workflow_test.rb
+++ b/test/system/users/registration_workflow_test.rb
@@ -124,5 +124,4 @@ class RegistrationWorkflowTest < ApplicationSystemTestCase
     fill_in 'user[password]', with: password
     fill_in 'user[password_confirmation]', with: password
   end
-
 end


### PR DESCRIPTION
Issue number: resolves #94 and an unreported bug

---------

### Description
After merging the validation for invited_by_id field #98, the production app started experimenting flaky registration success.
The issue occurred when the invite code was saved as uppercase in the DB. This is only the case for @noravonbreitenbach's code, as it was not automatically generated. 
The solution was to manually update that code and make it lowercase. 
This PR restores all the changes we made to try and fix the issue, and adds extra logging and flash messages in case something like this happens again.

### Checklist
- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Rubocop passes
