### PR TITLE
fix: strip user invite code to prevent issues

### DIFF
--- a/app/controllers/concerns/registration_concern.rb
+++ b/app/controllers/concerns/registration_concern.rb
@@ -61,9 +61,9 @@ module RegistrationConcern
   def find_invited_by
     return unless params[:invite_code].present?
 
-    @invited_by = User.find_by(invite_code: params[:invite_code].downcase)
+    @invited_by = User.find_by(invite_code: params[:invite_code].strip.downcase)
     if @invited_by.nil?
-      Rails.logger.warn("No user found with invite code: #{params[:invite_code]}")
+      Rails.logger.warn("No user found with invite code: '#{params[:invite_code]}'")
       return nil
     end
 

--- a/app/controllers/invites_controller.rb
+++ b/app/controllers/invites_controller.rb
@@ -4,8 +4,8 @@ class InvitesController < ApplicationController
   def invite_code_form; end
 
   def validate_invite_code
-    invite_code = params[:invite][:invite_code]
-    if User.exists?(invite_code: invite_code.strip) || User.exists?(invite_code: invite_code.strip.downcase)
+    invite_code = params[:invite][:invite_code].strip.downcase
+    if User.exists?(invite_code: invite_code)
       redirect_to new_user_registration_path(invite_code:)
     else
       flash[:alert] = 'Invite code not valid. Try again or contact the Quouch team'

--- a/test/controllers/concerns/registration_concern_test.rb
+++ b/test/controllers/concerns/registration_concern_test.rb
@@ -21,6 +21,49 @@ class RegistrationConcernTest < ActiveSupport::TestCase
     end
   end
 
+  test 'should find the user ID by invite code' do
+    other_user = FactoryBot.create(:user)
+    invite_code = other_user.invite_code
+
+    params[:invite_code] = invite_code
+    found_id = find_invited_by
+    assert_equal other_user.id, found_id
+  end
+
+  test 'should not find the user ID by invalid invite code' do
+    params[:invite_code] = 'invalid'
+    found_id = find_invited_by
+    assert_nil found_id
+  end
+
+  test 'should find the user ID when invite code is capitalized' do
+    other_user = FactoryBot.create(:user)
+    invite_code = other_user.invite_code
+
+    params[:invite_code] = invite_code.upcase
+    found_id = find_invited_by
+    assert_equal other_user.id, found_id
+  end
+
+  test 'should find the user ID when invite code includes spaces' do
+    other_user = FactoryBot.create(:user)
+    invite_code = other_user.invite_code
+
+    params[:invite_code] = "  #{invite_code}  "
+    found_id = find_invited_by
+    assert_equal other_user.id, found_id
+  end
+
+  test 'should update the user profile with beautified country' do
+    params[:user] = {
+      country: 'DE'
+    }
+
+    update_profile
+    @user.reload
+    assert_equal 'Germany', @user.country
+  end
+
   def params
     @params ||= {}
   end

--- a/test/integration/controllers/invites_controller_test.rb
+++ b/test/integration/controllers/invites_controller_test.rb
@@ -1,0 +1,31 @@
+require 'test_helper'
+
+class InvitesControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @user = FactoryBot.create(:user)
+  end
+
+  test "should get invite_code_form" do
+    get invite_code_path
+    assert_response :success
+  end
+
+  test "should validate invite code" do
+    get validate_invite_code_url, params: { invite: { invite_code: @user.invite_code } }
+    assert_redirected_to new_user_registration_path(invite_code: @user.invite_code)
+  end
+
+  test "should validate invite code with spaces" do
+    get validate_invite_code_url, params: { invite: { invite_code: @user.invite_code + ' ' } }
+    assert_redirected_to new_user_registration_path(invite_code: @user.invite_code)
+  end
+
+  test "should not validate invalid invite code" do
+    get validate_invite_code_url, params: { invite: { invite_code: 'invalid_code' } }
+    assert_response :unprocessable_entity
+
+    assert flash[:alert].present?
+    assert_includes flash[:alert], 'Invite code not valid'
+  end
+
+end


### PR DESCRIPTION
### Description
Prevent errors when the invite code is surrounded by blank spaces.

### Checklist
- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Rubocop passes
