### PR TITLE
fix: Create invite_code_helper and add code check step

### DIFF
--- a/app/controllers/concerns/registration_concern.rb
+++ b/app/controllers/concerns/registration_concern.rb
@@ -63,8 +63,8 @@ module RegistrationConcern
 
     @invited_by = User.find_by(invite_code: params[:invite_code].strip.downcase)
     if @invited_by.nil?
-      Sentry.capture_message("No user found with invite code: #{params[:invite_code]}")
-      Rails.logger.error("No user found with invite code: #{params[:invite_code]}")
+      Sentry.capture_message("No user found with invite code: #{params[:invite_code]}", level: 'info')
+      Rails.logger.warn("No user found with invite code: #{params[:invite_code]}")
       return nil
     end
 

--- a/app/controllers/invites_controller.rb
+++ b/app/controllers/invites_controller.rb
@@ -1,20 +1,34 @@
 class InvitesController < ApplicationController
+  include InviteCodeHelper
   skip_before_action :authenticate_user!, only: %i[invite_code_form validate_invite_code]
+
+  ERROR_MESSAGES = {
+    invalid_code: 'This does not look like a valid code. Please make sure you have the correct code or contact the Quouch Team',
+    invite_code_not_found: 'Invite code not found. Try again or contact the Quouch team',
+    default: 'Something went wrong. Please try again or contact the Quouch team'
+  }.freeze
 
   def invite_code_form; end
 
   def validate_invite_code
     invite_code = params[:invite][:invite_code].strip.downcase
-    begin
-      user = User.find_by!(invite_code: invite_code)
-      redirect_to new_user_registration_path(invite_code: invite_code) if user
-    rescue ActiveRecord::RecordNotFound => exception
-      flash[:alert] = 'Invite code not valid. Try again or contact the Quouch team'
-      Sentry.capture_exception(exception)
-      Sentry.capture_message("No user found with invite code: #{invite_code}")
-
+    if valid_syntax?(invite_code)
+      user = User.find_by!(invite_code:)
+      redirect_to new_user_registration_path(invite_code:) if user
+    else
+      flash[:alert] = ERROR_MESSAGES[:invalid_code]
       render :invite_code_form, status: :unprocessable_entity
+      nil
     end
+  rescue ActiveRecord::RecordNotFound => e
+    flash[:alert] = ERROR_MESSAGES[:invite_code_not_found]
+    Sentry.capture_exception(e)
+    Sentry.capture_message("No user found with invite code: #{invite_code}", level: 'info')
+
+    render :invite_code_form, status: :unprocessable_entity
+  rescue StandardError
+    flash[:alert] = ERROR_MESSAGES[:default]
+    render :invite_code_form, status: :unprocessable_entity
   end
 
   def invite_friend

--- a/app/helpers/invite_code_helper.rb
+++ b/app/helpers/invite_code_helper.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module InviteCodeHelper
+  def generate_random_code
+    SecureRandom.hex(3)
+  end
+
+  protected
+
+  def valid_syntax?(invite_code)
+    invite_code.match?(/^[a-zA-Z0-9]{6}$/)
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,6 +3,7 @@ class User < ApplicationRecord # rubocop:disable Metrics/ClassLength
   # :lockable, :trackable and :omniauthable
   include PgSearch::Model
   include Devise::JWT::RevocationStrategies::JTIMatcher
+  include InviteCodeHelper
 
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable, :confirmable,
@@ -95,7 +96,7 @@ class User < ApplicationRecord # rubocop:disable Metrics/ClassLength
 
   def generate_invite_code
     loop do
-      new_invite_code = SecureRandom.hex(3)
+      new_invite_code = generate_random_code
 
       unless User.exists?(invite_code: new_invite_code)
         self.invite_code = new_invite_code

--- a/test/controllers/concerns/couches_concern_test.rb
+++ b/test/controllers/concerns/couches_concern_test.rb
@@ -364,16 +364,4 @@ class CouchesConcernTest < ActiveSupport::TestCase
 
     new_characteristics
   end
-
-  def params
-    @params ||= {}
-  end
-
-  def session
-    @session ||= {}
-  end
-
-  def current_user
-    @user
-  end
 end

--- a/test/controllers/concerns/registration_concern_test.rb
+++ b/test/controllers/concerns/registration_concern_test.rb
@@ -84,12 +84,4 @@ class RegistrationConcernTest < ActiveSupport::TestCase
     @user.reload
     assert_equal 'Germany', @user.country
   end
-
-  def params
-    @params ||= {}
-  end
-
-  def session
-    @session ||= {}
-  end
 end

--- a/test/helpers/invite_code_helper_test.rb
+++ b/test/helpers/invite_code_helper_test.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class InviteCodeHelperTest < ActiveSupport::TestCase
+  include InviteCodeHelper
+
+  test 'should check that a six letter code is valid' do
+    code = 'abcdef'
+    assert valid_syntax?(code)
+  end
+
+  test 'should check that a six letter code with numbers is valid' do
+    code = '123456'
+    assert valid_syntax?(code)
+  end
+
+  test 'should check that a six letter code with numbers and letters is valid' do
+    code = 'abc123'
+    assert valid_syntax?(code)
+  end
+
+  test 'should check that a six letter code with special characters is invalid' do
+    code = 'abcde!'
+    assert_not valid_syntax?(code)
+  end
+
+  test 'should check that the generated code is valid' do
+    code = generate_random_code
+    assert valid_syntax?(code)
+  end
+
+  test 'should check that a code with less than six letters is invalid' do
+    code = 'abcde'
+    assert_not valid_syntax?(code)
+  end
+
+  test 'should check that a code with more than six letters is invalid' do
+    code = 'abcdefg'
+    assert_not valid_syntax?(code)
+  end
+end

--- a/test/integration/controllers/invites_controller_test.rb
+++ b/test/integration/controllers/invites_controller_test.rb
@@ -25,6 +25,14 @@ class InvitesControllerTest < ActionDispatch::IntegrationTest
     assert_response :unprocessable_entity
 
     assert flash[:alert].present?
-    assert_includes flash[:alert], 'Invite code not valid'
+    assert_includes flash[:alert], 'This does not look like a valid code'
+  end
+
+  test 'should not validate invite code that does not exist' do
+    get validate_invite_code_url, params: { invite: { invite_code: 'abcdef' } }
+    assert_response :unprocessable_entity
+
+    assert flash[:alert].present?
+    assert_includes flash[:alert], 'Invite code not found'
   end
 end

--- a/test/system/users/registration_workflow_test.rb
+++ b/test/system/users/registration_workflow_test.rb
@@ -25,6 +25,18 @@ class RegistrationWorkflowTest < ApplicationSystemTestCase
     assert_selector 'h1', text: 'Validate invite code'.upcase
   end
 
+  test 'should throw error if code does not exist' do
+    visit '/invite-code'
+
+    assert_selector 'h1', text: 'Validate invite code'.upcase
+
+    # Fill in the form
+    fill_in 'invite[invite_code]', with: 'abcdef'
+    click_on 'Validate'
+
+    assert_selector 'div.flash', text: 'Invite code not found'
+  end
+
   test 'should throw error if code is invalid' do
     visit '/invite-code'
 
@@ -34,7 +46,7 @@ class RegistrationWorkflowTest < ApplicationSystemTestCase
     fill_in 'invite[invite_code]', with: 'invalid'
     click_on 'Validate'
 
-    assert_selector 'div.flash', text: 'Invite code not valid'
+    assert_selector 'div.flash', text: 'This does not look like a valid code'
   end
 
   test 'should redirect to sign up page if code is valid' do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -59,6 +59,19 @@ module ActiveSupport
     fixtures :characteristics
 
     # Add more helper methods to be used by all tests here...
+
+    # default setup for all unit tests
+    def params
+      @params ||= {}
+    end
+
+    def session
+      @session ||= {}
+    end
+
+    def current_user
+      @user ||= {}
+    end
   end
 end
 


### PR DESCRIPTION
Issue number: resolves #119
---------

### Description
Show the user an error message when the invite code has an invalid format. This should prevent invite code errors being flagged when the code is truly invalid.

### Checklist
- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Rubocop passes
