### PR TITLE
chore: refactor user factory to use traits

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,3 +4,9 @@ QUOUCH_DATABASE_PASSWORD=
 
 BASE_USER_EMAIL=
 BASE_USER_PASSWORD=
+
+# Valid values: development, test, production
+RAILS_ENV=development
+
+# Change this to 'debug' to see all logs
+LOG_LEVEL=warn

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -12,6 +12,10 @@ Rails.application.configure do
     Bullet.raise         = false # raise an error if n+1 query occurs
   end
 
+  config.logger = Logger.new($stdout)
+
+  # Get the log level from the LOG_LEVEL environment variable or default to :warn.
+  config.log_level = ENV['LOG_LEVEL'] ? ENV['LOG_LEVEL'].to_sym : :warn
   # Settings specified here will take precedence over those in config/application.rb.
 
   # Turn false under Spring and add config.action_view.cache_template_loading = true.

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -92,7 +92,8 @@ user_password = ENV.fetch('BASE_USER_PASSWORD', nil)
 puts 'Create first user'
 User.destroy_all
 
-address = { street: 'Unter den Linden 77', city: 'Berlin', country: 'Germany', zipcode: '10117', country_code: 'DE' }
+address = { address: 'Unter den Linden 77, 10117 Berlin, Germany', city: 'Berlin', country: 'Germany',
+            zipcode: '10117' }
 
 base_user = User.new(
   email: user_email,
@@ -100,7 +101,7 @@ base_user = User.new(
   first_name: 'Admin',
   last_name: 'Local',
   confirmed_at: Time.now,
-  address: "#{address[:street]}, #{address[:zipcode]} #{address[:city]}, #{address[:country]}",
+  address: address[:address],
   zipcode: address[:zipcode],
   city: address[:city],
   country: address[:country]

--- a/lib/tasks/populate.rake
+++ b/lib/tasks/populate.rake
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'factory_bot_rails'
+
 namespace :dev do
   desc 'Fill database with sample data'
   task populate: :environment do
@@ -12,8 +14,8 @@ namespace :dev do
 
     puts 'Create 30 randomized users'
     30.times do
-      new_user = FactoryBot.create(:random_user)
-      puts "Created user with address: #{new_user.address}, #{new_user.zipcode} #{new_user.city}, #{new_user.country}"
+      new_user = FactoryBot.create(:user, :with_couch, :skip_validation)
+      puts "Created user with address: #{new_user.address}"
     end
   end
 

--- a/test/controllers/concerns/couches_concern_test.rb
+++ b/test/controllers/concerns/couches_concern_test.rb
@@ -11,7 +11,7 @@ class CouchesConcernTest < ActiveSupport::TestCase
     create_seed_user
 
     # Create the current user
-    @user = FactoryBot.create(:test_user_couch)
+    @user = FactoryBot.create(:user, :for_test, :with_couch)
   end
 
   test 'should get index' do
@@ -26,11 +26,11 @@ class CouchesConcernTest < ActiveSupport::TestCase
 
   test 'should not find users with active set to false' do
     # Create a user with an inactive couch
-    inactive_user = FactoryBot.create(:test_user_couch)
+    inactive_user = FactoryBot.create(:user, :for_test, :with_couch)
     inactive_user.couch.active = false
     inactive_user.couch.save!
     # Create one user with an active couch
-    FactoryBot.create(:test_user_couch)
+    FactoryBot.create(:user, :for_test, :with_couch)
 
     index
 
@@ -42,7 +42,7 @@ class CouchesConcernTest < ActiveSupport::TestCase
 
   test 'should return no results if city is not found' do
     # Create at least one user with couch
-    @host = FactoryBot.create(:test_user_couch)
+    @host = FactoryBot.create(:user, :for_test, :with_couch)
 
     # Filter for a city that doesn't exist
     params[:query] = 'Nonexistent City'
@@ -54,7 +54,7 @@ class CouchesConcernTest < ActiveSupport::TestCase
 
   test 'should search by city' do
     # Create at least one couch
-    @host = FactoryBot.create(:test_user_couch)
+    @host = FactoryBot.create(:user, :for_test, :with_couch)
 
     # Filter by city
     city = @host[:city]
@@ -68,7 +68,7 @@ class CouchesConcernTest < ActiveSupport::TestCase
 
   test 'should search by country' do
     # Create at least one couch
-    @host = FactoryBot.create(:test_user_couch, country: 'Canada')
+    @host = FactoryBot.create(:user, :for_test, :with_couch, country: 'Canada')
     @host.country = 'Canada'
     @host.save!
 
@@ -83,8 +83,8 @@ class CouchesConcernTest < ActiveSupport::TestCase
 
   test 'should apply characteristics filter' do
     # Create two couches
-    @host = FactoryBot.create(:test_user_couch)
-    @host2 = FactoryBot.create(:test_user_couch)
+    @host = FactoryBot.create(:user, :for_test, :with_couch)
+    @host2 = FactoryBot.create(:user, :for_test, :with_couch)
 
     # Create a characteristic and assign it to only one host
     characteristic1, characteristic2 = create_characteristics(2)
@@ -107,8 +107,8 @@ class CouchesConcernTest < ActiveSupport::TestCase
 
   test 'should apply multiple characteristics filter' do
     # Create two couches
-    @host = FactoryBot.create(:test_user_couch)
-    @host2 = FactoryBot.create(:test_user_couch)
+    @host = FactoryBot.create(:user, :for_test, :with_couch)
+    @host2 = FactoryBot.create(:user, :for_test, :with_couch)
 
     # Create some characteristics
     characteristic1, characteristic2 = create_characteristics(2)
@@ -126,11 +126,11 @@ class CouchesConcernTest < ActiveSupport::TestCase
 
   test 'should only return couches that offer hang out' do
     # Create two couches
-    @host = FactoryBot.create(:test_user_couch)
+    @host = FactoryBot.create(:user, :for_test, :with_couch)
     @host.offers_hang_out = true
     @host.save!
 
-    @host2 = FactoryBot.create(:test_user_couch)
+    @host2 = FactoryBot.create(:user, :for_test, :with_couch)
     @host2.offers_hang_out = false
     @host2.save!
 
@@ -145,11 +145,11 @@ class CouchesConcernTest < ActiveSupport::TestCase
 
   test 'should only return couches that offer co work' do
     # Create two couches
-    @host = FactoryBot.create(:test_user_couch)
+    @host = FactoryBot.create(:user, :for_test, :with_couch)
     @host.offers_co_work = false
     @host.save!
 
-    @host2 = FactoryBot.create(:test_user_couch)
+    @host2 = FactoryBot.create(:user, :for_test, :with_couch)
     @host2.offers_co_work = false
     @host2.save!
 
@@ -163,11 +163,11 @@ class CouchesConcernTest < ActiveSupport::TestCase
 
   test 'should only return couches that offer a couch' do
     # Create two couches
-    @host = FactoryBot.create(:test_user_couch)
+    @host = FactoryBot.create(:user, :for_test, :with_couch)
     @host.offers_couch = true
     @host.save!
 
-    @host2 = FactoryBot.create(:test_user_couch)
+    @host2 = FactoryBot.create(:user, :for_test, :with_couch)
     @host2.offers_couch = false
     @host2.save!
 
@@ -182,12 +182,12 @@ class CouchesConcernTest < ActiveSupport::TestCase
 
   test 'should combine offer and query filter' do
     # Create two couches
-    @host = FactoryBot.create(:test_user_couch)
+    @host = FactoryBot.create(:user, :for_test, :with_couch)
     @host.offers_couch = true
     @host.city = 'Test City'
     @host.save!
 
-    @host2 = FactoryBot.create(:test_user_couch)
+    @host2 = FactoryBot.create(:user, :for_test, :with_couch)
     @host2.offers_couch = true
     @host2.city = 'Another City'
     @host2.save!
@@ -204,15 +204,15 @@ class CouchesConcernTest < ActiveSupport::TestCase
 
   test 'should combine characteristic and offer filters' do
     # Create three couches
-    @host = FactoryBot.create(:test_user_couch)
+    @host = FactoryBot.create(:user, :for_test, :with_couch)
     @host.offers_couch = true
     @host.save!
 
-    @host2 = FactoryBot.create(:test_user_couch)
+    @host2 = FactoryBot.create(:user, :for_test, :with_couch)
     @host2.offers_couch = true
     @host2.save!
 
-    @host3 = FactoryBot.create(:test_user_couch)
+    @host3 = FactoryBot.create(:user, :for_test, :with_couch)
     @host3.offers_couch = false
     @host3.save!
 
@@ -234,15 +234,15 @@ class CouchesConcernTest < ActiveSupport::TestCase
 
   test 'should combine characteristic and query filters' do
     # Create three couches
-    @host = FactoryBot.create(:test_user_couch)
+    @host = FactoryBot.create(:user, :for_test, :with_couch)
     @host.city = 'Test City'
     @host.save!
 
-    @host2 = FactoryBot.create(:test_user_couch)
+    @host2 = FactoryBot.create(:user, :for_test, :with_couch)
     @host2.city = 'Another City'
     @host2.save!
 
-    @host3 = FactoryBot.create(:test_user_couch)
+    @host3 = FactoryBot.create(:user, :for_test, :with_couch)
     @host3.city = 'Test City'
     @host3.save!
 
@@ -264,17 +264,17 @@ class CouchesConcernTest < ActiveSupport::TestCase
 
   test 'should combine three different filters' do
     # Create three couches
-    @host = FactoryBot.create(:test_user_couch)
+    @host = FactoryBot.create(:user, :for_test, :with_couch)
     @host.offers_couch = true
     @host.city = 'Test City'
     @host.save!
 
-    @host2 = FactoryBot.create(:test_user_couch)
+    @host2 = FactoryBot.create(:user, :for_test, :with_couch)
     @host2.offers_couch = true
     @host2.city = 'Another City'
     @host2.save!
 
-    @host3 = FactoryBot.create(:test_user_couch)
+    @host3 = FactoryBot.create(:user, :for_test, :with_couch)
     @host3.offers_couch = false
     @host3.city = 'Test City'
     @host3.save!
@@ -348,7 +348,7 @@ class CouchesConcernTest < ActiveSupport::TestCase
   def setup_with_pagination
     # Create 10 couches
     10.times do
-      FactoryBot.create(:test_user_couch)
+      FactoryBot.create(:user, :for_test, :with_couch)
     end
 
     # Set up necessary conditions for the offers filter

--- a/test/controllers/concerns/registration_concern_test.rb
+++ b/test/controllers/concerns/registration_concern_test.rb
@@ -11,13 +11,13 @@ class RegistrationConcernTest < ActiveSupport::TestCase
     @user = FactoryBot.create(:user)
   end
 
-  test 'should beautify all countries in the addresses' do
-    ADDRESSES.each do |address|
+  ADDRESSES.each_with_index do |address, index|
+    define_method "test_should_beautify_address_#{index}" do
       params[:user] = {
         country: address[:country_code]
       }
 
-      assert_equal address[:country], beautify_country
+      assert_equal address[:country], beautify_country, "Address #{address[:address]} failed"
     end
   end
 

--- a/test/factories/users.rb
+++ b/test/factories/users.rb
@@ -29,33 +29,29 @@ FactoryBot.define do
       user.photo.attach(io: file, filename: 'avatar.png', content_type: 'image/png')
 
       random_address = ADDRESSES.sample
-      user.address = random_address[:street]
+      user.address = AddressHelper.format_address(random_address)
       user.zipcode = random_address[:zipcode]
       user.city = random_address[:city]
       user.country = random_address[:country]
     end
 
-    factory :random_user do
+    trait :skip_validation do
+      to_create do |instance|
+        instance.save(validate: false)
+      end
+    end
+
+    trait :with_couch do
       after(:create) do |user|
         # Needed for the search to work: add a couch for the newly created user
         Couch.create!(user:)
       end
     end
 
-    factory :test_user, class: User do
+    trait :for_test do
       offers_co_work { false }
       offers_hang_out { false }
       travelling { false }
-    end
-
-    factory :test_user_couch, class: User do
-      offers_co_work { false }
-      offers_hang_out { false }
-      travelling { false }
-
-      after(:create) do |user|
-        Couch.create!(user:)
-      end
     end
   end
 end

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -12,7 +12,7 @@ user_<%= n %>:
   offers_co_work: <%= true %>
   offers_hang_out: <%= true %>
   travelling: <%= true %>
-  address: <%= Faker::Address.street_address %>
+  address: <%= Faker::Address.full_address %>
   city: <%= Faker::Address.city %>
   zipcode: <%= Faker::Address.zip_code %>
   country: <%= Faker::Address.country %>
@@ -29,7 +29,7 @@ manual:
   first_name: 'Admin'
   last_name: 'Local'
   confirmed_at: <%=  Time.now %>
-  address: <%= Faker::Address.street_address %>
+  address: <%= Faker::Address.full_address %>
   city: <%= Faker::Address.city %>
   zipcode: <%= Faker::Address.zip_code %>
   country: <%= Faker::Address.country %>

--- a/test/helpers/addresses.rb
+++ b/test/helpers/addresses.rb
@@ -1,5 +1,11 @@
 # frozen_string_literal: true
 
+class AddressHelper
+  def self.format_address(address)
+    "#{address[:street]}, #{address[:zipcode]} #{address[:city]}, #{address[:country]}"
+  end
+end
+
 ADDRESSES = [
   { street: '123 Main St', city: 'New York', country: 'United States', zipcode: '10001', country_code: 'US' },
   { street: '456 Market St', city: 'San Francisco', country: 'United States', zipcode: '94105', country_code: 'US' },
@@ -24,25 +30,3 @@ ADDRESSES = [
   { street: '1 Austin Rd W', city: 'Hong Kong', country: 'Hong Kong', zipcode: 'HKG', country_code: 'HK' },
   { street: '111 Bourke St', city: 'Melbourne', country: 'Australia', zipcode: '3000', country_code: 'AU' }
 ].freeze
-
-# Parse the addresses to verify their existence in google maps
-# 123 Main St, New York, United States, 10001
-# 456 Market St, San Francisco, United States, 94105
-# 10 Downing St, London, United Kingdom, SW1A 2AA
-# Unter den Linden 77, Berlin, Germany, 10117
-# Piazza del Colosseo 1, Rome, Italy, 00184
-# Plaza de Cibeles 1, Madrid, Spain, 28014
-# Rue de la Loi 200, Brussels, Belgium, 1000
-# Av. Paulista, 1578, São Paulo, Brazil, 01310-200
-# Calle 10 # 5-51, Bogotá, Colombia, 111711
-# Av. 9 de Julio 1925, Buenos Aires, Argentina, C1072
-# Rue Dr. Robert Delmas, Port-au-Prince, Haiti, HT6110
-# Avenue Hassan II, Rabat, Morocco, 10030
-# Rue de Commerce, Dakar, Senegal, 18524
-# Jl. Medan Merdeka Selatan No.13, Jakarta, Indonesia, 10110
-# 2 Chome-3-1 Nishishinjuku, Tokyo, Japan, 163-8001
-# 350 Euston Rd, Mumbai, India, 400098
-# Jl. Jend. Sudirman Kav.52-53, Jakarta, Indonesia, 12190
-# 1 Austin Rd W, Hong Kong, Hong Kong, HKG
-# 111 Bourke St, Melbourne, Australia, 3000
-#

--- a/test/helpers/jwt_token_helper_test.rb
+++ b/test/helpers/jwt_token_helper_test.rb
@@ -51,7 +51,7 @@ class JwtTokenHelperTest < ActionView::TestCase
 
   test 'should raise error when the token does not match the user' do
     # Create a user
-    user = FactoryBot.create(:test_user)
+    user = FactoryBot.create(:user, :for_test)
 
     # Prepare a token
     token = generate_token({ sub: user.id, jti: '123', exp: Time.now.to_i + 10 })
@@ -66,7 +66,7 @@ class JwtTokenHelperTest < ActionView::TestCase
 
   test 'should find user by jwt token' do
     # Create a user
-    user = FactoryBot.create(:test_user)
+    user = FactoryBot.create(:user, :for_test)
 
     # Prepare a token
     token = generate_token({ sub: user.id, jti: user.jti, exp: Time.now.to_i + 10 })

--- a/test/helpers/sign_in_helper.rb
+++ b/test/helpers/sign_in_helper.rb
@@ -6,7 +6,7 @@ module SignInHelper
   end
 
   def api_prepare_headers
-    user = FactoryBot.create(:test_user_couch)
+    user = FactoryBot.create(:user, :for_test, :with_couch)
     # Ensure that the city is unique, so we don't have to worry about it in the tests
     user.city = 'Test city'
     user.country = 'Test country'

--- a/test/helpers/user_helper.rb
+++ b/test/helpers/user_helper.rb
@@ -1,6 +1,6 @@
 module UserHelper
   def create_user_with(email:, password:)
-    @user = FactoryBot.build(:test_user, email:, password:)
+    @user = FactoryBot.build(:user, :for_test, email:, password:)
     @user.save!
     Couch.create!(user: @user)
     @user
@@ -15,7 +15,7 @@ module UserHelper
       first_name: Faker::Name.first_name,
       last_name: Faker::Name.last_name,
       confirmed_at: Time.now,
-      address: random_address[:street],
+      address: AddressHelper.format_address(random_address),
       zipcode: random_address[:zipcode],
       city: random_address[:city],
       country: random_address[:country],

--- a/test/integration/controllers/api/v1/users/sessions_controller_test.rb
+++ b/test/integration/controllers/api/v1/users/sessions_controller_test.rb
@@ -7,7 +7,7 @@ module Api
         include Devise::Test::IntegrationHelpers
 
         def setup
-          @user = FactoryBot.create(:test_user)
+          @user = FactoryBot.create(:user, :for_test)
           @user.password = 'password'
           @user.save!
         end

--- a/test/integration/controllers/couches_controller_test.rb
+++ b/test/integration/controllers/couches_controller_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class CouchesControllerTest < ActionDispatch::IntegrationTest
   setup do
-    @user = FactoryBot.create(:test_user_couch)
+    @user = FactoryBot.create(:user, :for_test, :with_couch)
     sign_in_as(@user)
   end
 

--- a/test/integration/controllers/users/registrations_controller_test.rb
+++ b/test/integration/controllers/users/registrations_controller_test.rb
@@ -5,7 +5,7 @@ module Users
     include Devise::Test::IntegrationHelpers
 
     setup do
-      fake_user_data = FactoryBot.build(:test_user)
+      fake_user_data = FactoryBot.build(:user, :for_test)
       random_address = ADDRESSES.sample
 
       file = URI.parse(Faker::Avatar.image).open
@@ -19,7 +19,7 @@ module Users
         date_of_birth: fake_user_data[:date_of_birth],
         summary: fake_user_data[:summary],
         offers_couch: true,
-        address: random_address[:street],
+        address: AddressHelper.format_address(random_address),
         zipcode: random_address[:zipcode],
         city: random_address[:city],
         country: random_address[:country_code],
@@ -47,7 +47,7 @@ module Users
     end
 
     test 'should send a flash message if there is an issue with the invite code' do
-      inviting_user = FactoryBot.create(:test_user)
+      inviting_user = FactoryBot.create(:user, :for_test)
       # Make the invite code invalid
       inviting_user.invite_code = 'ABC123'
       inviting_user.save
@@ -62,7 +62,7 @@ module Users
     end
 
     test 'should create a user with an invite code' do
-      inviting_user = FactoryBot.create(:test_user)
+      inviting_user = FactoryBot.create(:user, :for_test)
 
       # expect success
       post user_registration_url,

--- a/test/integration/couches_filter_test.rb
+++ b/test/integration/couches_filter_test.rb
@@ -4,7 +4,7 @@ require 'test_helper'
 
 class CouchesFilterTest < ActionDispatch::IntegrationTest
   setup do
-    @user = FactoryBot.create(:test_user_couch)
+    @user = FactoryBot.create(:user, :for_test, :with_couch)
     sign_in_as(@user)
   end
 

--- a/test/models/couch_test.rb
+++ b/test/models/couch_test.rb
@@ -8,7 +8,7 @@ class CouchTest < ActiveSupport::TestCase
 
   test 'should save couch with a user' do
     create_seed_user
-    @user = FactoryBot.create(:test_user)
+    @user = FactoryBot.create(:user, :for_test)
 
     couch = Couch.new(user: @user)
     assert couch.valid?

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -4,7 +4,7 @@ class UserTest < ActiveSupport::TestCase
   fixtures :users
 
   def setup
-    @user = FactoryBot.build(:test_user)
+    @user = FactoryBot.build(:user, :for_test)
   end
 
   test 'should not save user without a first name' do

--- a/test/system/couches_filter_and_navigation_test.rb
+++ b/test/system/couches_filter_and_navigation_test.rb
@@ -4,7 +4,7 @@ require 'system_test_helper'
 
 class CouchesFilterAndNavigationTest < ApplicationSystemTestCase
   setup do
-    @user = FactoryBot.create(:test_user_couch)
+    @user = FactoryBot.create(:user, :for_test, :with_couch)
     sign_in_as(@user)
   end
 

--- a/test/system/users/registration_workflow_test.rb
+++ b/test/system/users/registration_workflow_test.rb
@@ -6,15 +6,15 @@ class RegistrationWorkflowTest < ApplicationSystemTestCase
   def setup
     random_address = ADDRESSES.first
 
-    @fake_user_data = FactoryBot.build(:test_user)
-    @fake_user_data[:address] = random_address[:street]
+    @fake_user_data = FactoryBot.build(:user, :for_test)
+    @fake_user_data[:address] = AddressHelper.format_address(random_address)
     @fake_user_data[:zipcode] = random_address[:zipcode]
     @fake_user_data[:city] = random_address[:city]
     @fake_user_data[:country] = random_address[:country_code]
 
     @avatar = URI.parse(Faker::Avatar.image).open
 
-    @inviting_user = FactoryBot.create(:test_user_couch)
+    @inviting_user = FactoryBot.create(:user, :for_test, :with_couch)
   end
 
   test 'should open validate invite code page' do
@@ -119,7 +119,7 @@ class RegistrationWorkflowTest < ApplicationSystemTestCase
     fill_in 'user[summary]', with: @fake_user_data[:summary]
 
     # Fill in the address
-    formatted_address = "#{@fake_user_data[:address]}, #{@fake_user_data[:zipcode]} #{@fake_user_data[:city]}, #{@fake_user_data[:country]}"
+    formatted_address = AddressHelper.format_address(ADDRESSES.first)
     fill_in 'Search', with: formatted_address
     first_suggestion = first('.mapboxgl-ctrl-geocoder--suggestion')
     first_suggestion.click


### PR DESCRIPTION
### Description
This should help the readability of test files. From the [ThoughtBot blog](https://thoughtbot.com/blog/remove-duplication-with-factorybots-traits):
> [FactoryBot](https://github.com/thoughtbot/factory_bot)’s traits are an outstanding way to DRY up your tests and factories by naming groups of attributes, callbacks, and associations in one concise area. 

I used this to replace `:test_user`, `:random_user` and `:test_user_couch`, which are names that in a way obscure what's going on. Instead, we can use `:user, :for_test, :with_couch` and explicitly name what we want the user to have.

Additionally, added an address helper class for formatting the address

### Changelog
- **Added `RAILS_ENV` to the example .env file**: this value can be used e.g. to simulate the test environment, but it defaults to `development`!
- **Added LOG_LEVEL to `.env` and config files**: we were not seeing any logging in the tests, so I added this as a configurable variable that defaults to `warn`
- `AddressHelper` should be used to properly format the addresses in a central place
- Added "traits" to `user` factory and use traits where needed

### Checklist
- [x] Code compiles correctly
- [x] All tests passing
- [x] Rubocop passes
