### PR TITLE
fix: remove development from sentry to reduce potential costs

### DIFF
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -17,5 +17,5 @@ Sentry.init do |config|
   # We recommend adjusting this value in production.
   config.profiles_sample_rate = 1.0
 
-  config.enabled_environments = %w[production staging development]
+  config.enabled_environments = %w[production staging]
 end


### PR DESCRIPTION
### Description
Sentry's pricing model is per-error. I forgot to disable logging from development after I was done with the tests!