### PR TITLE
fix: send reminders only for future bookings

### DIFF
--- a/app/controllers/bookings_controller.rb
+++ b/app/controllers/bookings_controller.rb
@@ -175,7 +175,7 @@ class BookingsController < ApplicationController
   def categorize_booking(booking)
     if booking.pending? || booking.pending_reconfirmation? || booking.confirmed?
       :upcoming
-    elsif booking.cancelled? || booking.declined?
+    elsif booking.cancelled? || booking.declined? || booking.expired?
       :cancelled
     else
       :completed

--- a/app/models/booking.rb
+++ b/app/models/booking.rb
@@ -40,7 +40,10 @@ class Booking < ApplicationRecord
   end
 
   def self.remind
-    pending_future_bookings = Booking.where(status: 0).where('start_date >= ?', Date.today)
+    pending_future_bookings = Booking.where(status: 0).where('start_date >= ?',
+                                                             Date.today).or(Booking.where(status: 0).where(
+                                                                              start_date: nil, flexible: true
+                                                                            ))
     pending_past_bookings = Booking.where(status: 0).where('start_date < ?', Date.today)
     pending_past_bookings.update_all(status: -2)
     return if pending_future_bookings.empty?

--- a/app/models/booking.rb
+++ b/app/models/booking.rb
@@ -36,20 +36,20 @@ class Booking < ApplicationRecord
     return if completed_bookings.empty?
 
     send_completed_emails(completed_bookings)
-    update_status(completed_bookings)
+    update_status(completed_bookings, 4)
   end
 
   def self.remind
     pending_future_bookings = Booking.where(status: 0).where('start_date >= ?', Date.today)
     pending_past_bookings = Booking.where(status: 0).where('start_date < ?', Date.today)
     pending_past_bookings.update_all(status: -2)
-    return if pending_bookings.empty?
+    return if pending_future_bookings.empty?
 
     send_reminder_emails(pending_future_bookings)
   end
 
-  def self.update_status(bookings)
-    bookings.update_all(status: 4)
+  def self.update_status(bookings, status)
+    bookings.update_all(status:)
   end
 
   def self.send_completed_emails(bookings)

--- a/app/views/bookings/index.html.erb
+++ b/app/views/bookings/index.html.erb
@@ -108,7 +108,7 @@
       <% end %>
 
       <% if @cancelled.any? %>
-        <h2 class="bookings__title">Declined and Cancelled Trips</h2>
+        <h2 class="bookings__title">Cancelled, Declined & Expired Trips</h2>
         <ul class="past-bookings">
           <% @cancelled.each do |booking| %>
             <%= link_to booking_path(booking) do %>

--- a/app/views/bookings/requests.html.erb
+++ b/app/views/bookings/requests.html.erb
@@ -102,7 +102,7 @@
       <% end %>
 
       <% if @cancelled.any? %>
-        <h2 class="requests__title">Cancelled Requests</h2>
+        <h2 class="requests__title">Cancelled, Declined & Expired Bookings</h2>
         <ul class="past-requests">
           <% @cancelled.each do |request| %>
             <%= link_to request_booking_path(request) do %>

--- a/test/factories/bookings.rb
+++ b/test/factories/bookings.rb
@@ -26,6 +26,13 @@ FactoryBot.define do
       status { 0 }
     end
 
+    trait :future_pending_flexible do
+      start_date { nil }
+      end_date { nil }
+      flexible { true }
+      status { 0 }
+    end
+
     trait :confirmed do
       status { 1 }
     end
@@ -38,7 +45,7 @@ FactoryBot.define do
       status { 3 }
     end
 
-    trait :completed do
+    trait :to_be_completed do
       start_date { Date.today - 2 }
       end_date { Date.today - 1 }
       status { 1 }

--- a/test/factories/bookings.rb
+++ b/test/factories/bookings.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :booking do
+    start_date { Date.today }
+    end_date { Date.today + 1 }
+    request { [0, 1, 2].sample }
+    message { Faker::Hipster.paragraph_by_chars(characters: 60) }
+    number_travellers { 1 }
+    association :user, factory: %i[user with_couch skip_validation]
+
+    after(:build) do |booking|
+      couch_owner = FactoryBot.create(:user, :with_couch, :skip_validation)
+      booking.couch = couch_owner.couch
+    end
+
+    trait :past_pending do
+      start_date { Date.today - 2 }
+      end_date { Date.today - 1 }
+      status { 0 }
+    end
+
+    trait :future_pending do
+      start_date { Date.today }
+      end_date { Date.today + 1 }
+      status { 0 }
+    end
+
+    trait :confirmed do
+      status { 1 }
+    end
+
+    trait :declined do
+      status { 2 }
+    end
+
+    trait :pending_reconfirmation do
+      status { 3 }
+    end
+
+    trait :completed do
+      start_date { Date.today - 2 }
+      end_date { Date.today - 1 }
+      status { 1 }
+    end
+
+    trait :cancelled do
+      status { -1 }
+    end
+
+    trait :expired do
+      status { -2 }
+    end
+  end
+end

--- a/test/factories/users.rb
+++ b/test/factories/users.rb
@@ -44,7 +44,7 @@ FactoryBot.define do
     trait :with_couch do
       after(:create) do |user|
         # Needed for the search to work: add a couch for the newly created user
-        Couch.create!(user:)
+        Couch.create!(user:, capacity: 1)
       end
     end
 

--- a/test/models/booking_test.rb
+++ b/test/models/booking_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 class BookingTest < ActiveSupport::TestCase
   include ActionMailer::TestHelper
   test 'complete should send completed emails and update status' do
-    booking = FactoryBot.create(:booking, :completed)
+    booking = FactoryBot.create(:booking, :to_be_completed)
 
     assert_emails 2 do
       Booking.complete
@@ -15,11 +15,13 @@ class BookingTest < ActiveSupport::TestCase
   test 'remind should update status of past pending bookings to expired and send reminder emails for future bookings' do
     past_pending_booking = FactoryBot.create(:booking, :past_pending)
     future_pending_booking = FactoryBot.create(:booking, :future_pending)
+    future_pending_flexible_booking = FactoryBot.create(:booking, :future_pending_flexible)
     Booking.remind
 
     assert_equal 'expired', past_pending_booking.reload.status
     assert_equal 'pending', future_pending_booking.reload.status
-    assert_emails 1
+    assert_equal 'pending', future_pending_flexible_booking.reload.status
+    assert_emails 2
   end
 
   test 'update_status should update status of given bookings' do
@@ -33,7 +35,7 @@ class BookingTest < ActiveSupport::TestCase
   end
 
   test 'send_completed_emails should send emails to guest and host' do
-    booking = FactoryBot.create(:booking, :completed)
+    booking = FactoryBot.create(:booking, :to_be_completed)
     assert_emails 2 do
       Booking.send_completed_emails([booking])
     end

--- a/test/models/booking_test.rb
+++ b/test/models/booking_test.rb
@@ -1,7 +1,49 @@
 require 'test_helper'
 
 class BookingTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  include ActionMailer::TestHelper
+  test 'complete should send completed emails and update status' do
+    booking = FactoryBot.create(:booking, :completed)
+
+    assert_emails 2 do
+      Booking.complete
+    end
+
+    assert_equal 'completed', booking.reload.status
+  end
+
+  test 'remind should update status of past pending bookings to expired and send reminder emails for future bookings' do
+    past_pending_booking = FactoryBot.create(:booking, :past_pending)
+    future_pending_booking = FactoryBot.create(:booking, :future_pending)
+    Booking.remind
+
+    assert_equal 'expired', past_pending_booking.reload.status
+    assert_equal 'pending', future_pending_booking.reload.status
+    assert_emails 1
+  end
+
+  test 'update_status should update status of given bookings' do
+    FactoryBot.create_list(:booking, 2, :pending)
+    bookings_relation = Booking.where(status: 'pending')
+    Booking.update_status(bookings_relation, 'confirmed')
+
+    bookings_relation.each do |booking|
+      assert_equal 'confirmed', booking.reload.status
+    end
+  end
+
+  test 'send_completed_emails should send emails to guest and host' do
+    booking = FactoryBot.create(:booking, :completed)
+    assert_emails 2 do
+      Booking.send_completed_emails([booking])
+    end
+  end
+
+  test 'send_reminder_emails should send reminder emails to hosts' do
+    booking = FactoryBot.create(:booking, :future_pending)
+
+    assert_emails 1 do
+      Booking.send_reminder_emails([booking])
+    end
+  end
 end


### PR DESCRIPTION
To avoid exceeding our SMTP limit, this PR implements the following changes:

- it as of now only sends reminder emails for pending bookings that lay in the future
- it sets pending bookings that lay in the past to expired in the same run

### Checklist
- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Rubocop passes
