### PR TITLE
feat: refactor user to validate on update

### DIFF
--- a/app/assets/stylesheets/components/_user-form.scss
+++ b/app/assets/stylesheets/components/_user-form.scss
@@ -1,326 +1,364 @@
 .user {
-	background-color: $primary-transparent;
-	margin-top: 2rem;
+    background-color: $primary-transparent;
 
-	h1 {
-		margin-bottom: .5rem;
-		margin-right: 1rem;
-		margin-left: 1rem;
-	}
-	
-	label {
-		@include body-2;
+    &:first-child {
+        margin-top: 2rem;
+    }
 
-		margin: 1rem 0;
-		text-transform: uppercase;
-	}
+    h1 {
+        margin-bottom: .5rem;
+        margin-right: 1rem;
+        margin-left: 1rem;
+    }
 
-	&__header-link {
-		@include tertiary-button;
+    label {
+        @include body-2;
 
-		display: block;
-		text-align: center; 
-	}
+        margin: 1rem 0;
+        text-transform: uppercase;
 
-	&__form {
-		@include container-width;
-		margin: 0 auto;
-	}
+        display: flex;
+        flex-direction: row;
+        gap: .3rem;
+    }
 
-	&__wrap {
-		@media (min-width: $break-medium) {
-			display: flex;
-			gap: 4rem;
-		}
-	}
+    &__header-link {
+        @include tertiary-button;
 
-	&__info { width: 100%; }
+        display: block;
+        text-align: center;
+    }
 
-	&__image {
-		display: flex;
-		flex-direction: column;
-		align-items: center;
-		min-width: 200px;
+    &__form {
+        @include container-width;
+        margin: 0 auto;
+    }
 
-		> label { margin: 1rem auto; }
+    &__wrap {
+        @media (min-width: $break-medium) {
+            display: flex;
+            gap: 4rem;
+        }
+    }
 
-		@media (min-width: $break-medium) { align-items: flex-start; }
+    &__info {
+        width: 100%;
+    }
 
-		&-preview {
-			display: inline-block;
-			width: 200px;
-			height: 200px;
-			border-radius: $border-radius-round;
-			object-fit: cover;
-			object-position: center;
-		}
+    &__image {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        min-width: 200px;
 
-		&-icon {
-			width: 200px;
-			height: 200px;
-			border-radius: $border-radius-round;
-			background-color: $secondary-transparent;
+        > label {
+            margin: 1rem auto;
+        }
 
-			font-size: 200px;
+        @media (min-width: $break-medium) {
+            align-items: flex-start;
+        }
+
+        &-preview {
+            display: inline-block;
+            width: 200px;
+            height: 200px;
+            border-radius: $border-radius-round;
+            object-fit: cover;
+            object-position: center;
+        }
+
+        &-icon {
+            width: 200px;
+            height: 200px;
+            border-radius: $border-radius-round;
+            background-color: $secondary-transparent;
+
+            font-size: 200px;
             overflow: hidden;
             display: flex;
             justify-content: center;
         }
 
-		&-upload {
-			display: flex;
-			gap: .3rem;
-			margin: 1rem auto 0;
+        &-upload {
+            display: flex;
+            gap: .3rem;
+            margin: 1rem auto 0;
 
             i {
                 font-size: 24px;
             }
 
-			&:hover { opacity: .7; }
-		}
-	}
+            label {
+                display: inline;
+            }
 
-	&__info {
-		display: flex;
-		flex-direction: column;
-	}
+            &:hover {
+                opacity: .7;
+            }
+        }
+    }
 
-	&__birthdate {
-		display: flex;
-		gap: .5rem;
-		align-items: center;
+    &__info {
+        display: flex;
+        flex-direction: column;
+    }
 
-		select {
-			background-color: $white;
-			flex-grow: 1;
-		}
-	}
+    &__birthdate {
+        display: flex;
+        gap: .5rem;
+        align-items: center;
 
-	&__address {
-    margin-top: 1rem;
+        select {
+            background-color: $white;
+            flex-grow: 1;
+        }
+    }
 
-		&-street {
-      display: flex;
-			column-gap: 1rem;
-			align-items: center;
+    &__address {
+        margin-top: 1rem;
 
-      .user_address { width: 100%; }
+        &-street {
+            display: flex;
+            column-gap: 1rem;
+            align-items: center;
 
-      .mapboxgl-ctrl-geocoder.mapboxgl-ctrl {
-        min-width: 0;
-        height: 40px;
+            .user_address {
+                width: 100%;
+            }
 
-				@media (min-width: $break-small) {
-					min-width: 100%;	
-					width: 100%;
-				}
+            .mapboxgl-ctrl-geocoder.mapboxgl-ctrl {
+                min-width: 0;
+                height: 40px;
 
-				@media (min-width: $break-large) { height: 46px; }
-				
-				.mapboxgl-ctrl-geocoder--input {
-					height: auto;
-					padding: 6px 10px;
-				}
-      }
+                @media (min-width: $break-small) {
+                    min-width: 100%;
+                    width: 100%;
+                }
 
-		}
+                @media (min-width: $break-large) {
+                    height: 46px;
+                }
 
-		&-wrap {
-			display: flex;
-			column-gap: 1.4rem;
-			align-items: center;
-			@media (min-width: $break-medium) { width: 100%; }
+                .mapboxgl-ctrl-geocoder--input {
+                    height: auto;
+                    padding: 6px 10px;
+                }
+            }
 
-			&--city {
-				@media (max-width: $break-medium) { column-gap: 3.3rem; } // shame
-			}
-		}
+        }
 
-		&-city {
-			@media (min-width: $break-medium) {
-				display: flex;
-				column-gap: 1.5rem;
-				align-items: center;
-			}
-			> div { flex-grow: 1; }
-			input { width: 100%; }
-		}
+        &-wrap {
+            display: flex;
+            column-gap: 1.4rem;
+            align-items: center;
+            @media (min-width: $break-medium) {
+                width: 100%;
+            }
 
-		&-country {
-			display: flex;
-			column-gap: 1rem;
-			align-items: center;
+            &--city {
+                @media (max-width: $break-medium) {
+                    column-gap: 3.3rem;
+                }
+                // shame
+            }
+        }
 
-			.input, .input select { width: 100%; }
-			.input select {
-				background-color: $white;
-				
-				@media (min-width: $break-large) { height: 46px; }
-			}
-		}
+        &-city {
+            @media (min-width: $break-medium) {
+                display: flex;
+                column-gap: 1.5rem;
+                align-items: center;
+            }
 
-		&-label {
-			display: flex;
-			flex-direction: row;
-			gap: .3rem;
-		}
-	}
+            > div {
+                flex-grow: 1;
+            }
 
-	&__characteristics {
-		display: grid;
-		grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
-		margin: 1rem 0;
+            input {
+                width: 100%;
+            }
+        }
 
-		span {
-			label {
-				@include body-3;
+        &-country {
+            display: flex;
+            column-gap: 1rem;
+            align-items: center;
 
-				display: flex;
-				align-items: center;
-				gap: .3rem;
-				margin: .5rem 0;
+            .input, .input select {
+                width: 100%;
+            }
 
-				label {
-					flex-shrink: 0;
-					margin: 0;
-				}
-			}
-		}
-	}
+            .input select {
+                background-color: $white;
 
-	&__travelling { margin: 1rem 0 .5rem; }
+                @media (min-width: $break-large) {
+                    height: 46px;
+                }
+            }
+        }
+    }
 
-	&__offers {
-		@media (min-width: $break-medium) {
-			display: flex;
-			flex-wrap: wrap;
-			column-gap: 2rem;
-		}
-	}
+    &__characteristics {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+        margin: 1rem 0;
 
-	&__offer {
-		display: flex;
-		align-items: center;
-		gap: .3rem;
-		flex-shrink: 0;
+        span {
+            label {
+                @include body-3;
 
-		label {
-			@include body-3;
+                display: flex;
+                align-items: center;
+                gap: .3rem;
+                margin: .5rem 0;
 
-			margin: .5rem 0;
-		}
+                label {
+                    flex-shrink: 0;
+                    margin: 0;
+                }
+            }
+        }
+    }
+
+    &__travelling {
+        margin: 1rem 0 .5rem;
+    }
+
+    &__offers {
+        @media (min-width: $break-medium) {
+            display: flex;
+            flex-wrap: wrap;
+            column-gap: 2rem;
+        }
+    }
+
+    &__offer {
+        display: flex;
+        align-items: center;
+        gap: .3rem;
+        flex-shrink: 0;
+
+        label {
+            @include body-3;
+
+            margin: .5rem 0;
+        }
+
         i {
             font-size: 24px;
         }
     }
 
-	&__couch {
-		&-capacity {
-			select {
-				background-color: $white;
-				margin: 1rem .3rem;
-			}
-		}
+    &__couch {
+        &-capacity {
+            select {
+                background-color: $white;
+                margin: 1rem .3rem;
+            }
+        }
 
-		&-facilities {
-			display: grid;
-			grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+        &-facilities {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
 
-			span {
-				label {
-					@include body-3;
+            span {
+                label {
+                    @include body-3;
 
-					display: flex;
-					align-items: center;
-					gap: .3rem;
-					margin: .5rem 0;
+                    display: flex;
+                    align-items: center;
+                    gap: .3rem;
+                    margin: .5rem 0;
 
-					label {
-						flex-shrink: 0;
-						margin: 0;
-					}
-				}
-			}
-		}
-	}
+                    label {
+                        flex-shrink: 0;
+                        margin: 0;
+                    }
+                }
+            }
+        }
+    }
 
 
-	&__password {
-		&-change { color: $primary; }
-	}
+    &__password {
+        &-change {
+            color: $primary;
+        }
+    }
 
-	&__hint { font-size: .75rem; }
+    &__hint {
+        font-size: .75rem;
+    }
 
-	&__submit {
-		input {
-			@include primary-button;
-			margin: 1rem 0;
+    &__submit {
+        input {
+            @include primary-button;
+            margin: 1rem 0;
 
-			@media (min-width: $break-large) {
-				width: fit-content;
-			}
-		}
-	}
+            @media (min-width: $break-large) {
+                width: fit-content;
+            }
+        }
+    }
 
-	&__cancel {
-		@include container-width;
-		width: 80%;
-		margin: 1rem auto;
-		display: flex;
-		align-items: center;
+    &__cancel {
+        @include container-width;
+        width: 80%;
+        margin: 1rem auto;
+        display: flex;
+        align-items: center;
 
-		&-link {
-			@include input-field;
-			@include tertiary-button;
+        &-link {
+            @include input-field;
+            @include tertiary-button;
 
-			background-color: transparent;
-		}
-	}
+            background-color: transparent;
+        }
+    }
 
-	&__password {
-		display: flex;
-		flex-direction: column;
+    &__password {
+        display: flex;
+        flex-direction: column;
+    }
 
-		&-label {
-			flex-direction: row;
-			gap: .3rem;
-		}
-	}
-
-	&__footer {
-		display: flex;
-		justify-content: center;
-	}
+    &__footer {
+        display: flex;
+        justify-content: center;
+    }
 }
 
 .user_pronouns {
-	display: flex;
-	flex-direction: column;
+    display: flex;
+    flex-direction: column;
 }
 
 .mapboxgl-ctrl-geocoder {
-	@include input-field;
+    @include input-field;
 
-	box-shadow: 0 0 0 0;
-	display: flex;
-	align-items: center;
-	padding: 0;
+    box-shadow: 0 0 0 0;
+    display: flex;
+    align-items: center;
+    padding: 0;
 
-	&--icon {
-		display: block;
-		margin-left: 1rem;
-		position: inherit;
-		top: 0;
-		left: 0;
-		right: 0;
-		bottom: 0;
-	}
-	&--icon-search {
-		top: 0px;
-		left: 0px;
-		width: 20px;
-		height: 20px;
-	}
+    &--icon {
+        display: block;
+        margin-left: 1rem;
+        position: inherit;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+    }
+
+    &--icon-search {
+        top: 0px;
+        left: 0px;
+        width: 20px;
+        height: 20px;
+    }
 }
 
-#user__characteristics-title { margin-bottom: .3rem; }
+#user__characteristics-title {
+    margin-bottom: .3rem;
+}

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,7 +8,7 @@ class ApplicationController < ActionController::Base
   def configure_permitted_parameters
     # For additional fields in app/views/users/registrations/new.html.erb
     devise_parameter_sanitizer.permit(:sign_up, keys: [:photo, :first_name, :last_name, :date_of_birth,
-                                                       :pronouns, :address, :street, :zipcode, :city, :country, :summary,
+                                                       :pronouns, :address, :street, :zipcode, :city, :country_code, :summary,
                                                        :passion, :travelling,
                                                        :offers_couch, :offers_co_work, :offers_hang_out, :question_one, :question_two,
                                                        :question_three, :question_four, :address,
@@ -17,7 +17,7 @@ class ApplicationController < ActionController::Base
 
     # For additional in app/views/users/registrations/edit.html.erb
     devise_parameter_sanitizer.permit(:account_update, keys: [:photo, :first_name, :last_name, :date_of_birth, :pronouns,
-                                                              :address, :street, :zipcode, :city, :country, :summary,
+                                                              :address, :street, :zipcode, :city, :country_code, :summary,
                                                               :passion, :travelling, :offers_couch,
                                                               :offers_co_work, :offers_hang_out, :question_one, :question_two,
                                                               :question_three, :question_four, :address,

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -24,6 +24,6 @@ class ApplicationController < ActionController::Base
                                                               { user_characteristic_attributes: [:characteristic_ids], couch_attributes: [:capacity],
                                                                 couch_facility_attributes: [:facility_ids] }])
 
-    devise_parameter_sanitizer.permit(:password_update, keys: [:old_password, :password, :password_confirmation])
+    devise_parameter_sanitizer.permit(:password_update, keys: %i[old_password password password_confirmation])
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -23,5 +23,7 @@ class ApplicationController < ActionController::Base
                                                               :question_three, :question_four, :address,
                                                               { user_characteristic_attributes: [:characteristic_ids], couch_attributes: [:capacity],
                                                                 couch_facility_attributes: [:facility_ids] }])
+
+    devise_parameter_sanitizer.permit(:password_update, keys: [:old_password, :password, :password_confirmation])
   end
 end

--- a/app/controllers/concerns/registration_concern.rb
+++ b/app/controllers/concerns/registration_concern.rb
@@ -37,6 +37,11 @@ module RegistrationConcern
 
   def create_couch_facilities
     @couch.couch_facilities.destroy_all
+    if params[:couch_facility].nil? || params[:couch_facility][:facility_ids].nil?
+      Rails.logger.info('No facilities selected for couch')
+      return
+    end
+
     couch_facility_params[:facility_ids].reject(&:empty?).each do |id|
       CouchFacility.create(couch_id: @couch.id, facility_id: id)
     end
@@ -74,8 +79,9 @@ module RegistrationConcern
 
   def update_profile
     begin
-      @user.update(country: beautify_country)
-      Rails.logger.info("Updated user profile with country: #{beautify_country}")
+      parsed_country = beautify_country
+      @user.update(country: parsed_country)
+      Rails.logger.info("Updated user profile with country: #{parsed_country}")
     rescue ArgumentError => e
       Sentry.capture_exception(e)
     end

--- a/app/controllers/concerns/registration_concern.rb
+++ b/app/controllers/concerns/registration_concern.rb
@@ -37,13 +37,17 @@ module RegistrationConcern
 
   def create_couch_facilities
     @couch.couch_facilities.destroy_all
-    if params[:couch_facility].nil? || params[:couch_facility][:facility_ids].nil?
+
+    if params[:couch_facility].nil? || params[:couch_facility].empty?
       Rails.logger.info('No facilities selected for couch')
       return
     end
 
-    couch_facility_params[:facility_ids].reject(&:empty?).each do |id|
-      CouchFacility.create(couch_id: @couch.id, facility_id: id)
+    facilities_to_create = couch_facility_params[:facility_ids].reject(&:empty?)
+    raise ArgumentError, 'Please select at least one facility.' if facilities_to_create.empty?
+
+    facilities_to_create.each do |id|
+      @couch.couch_facilities.create(facility_id: id)
     end
   end
 

--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Users
+  class PasswordsController < Devise::PasswordsController
+    def update
+      super do |resource|
+        Rails.logger.error("Password update failed for user. Reasons: #{resource.errors.full_messages}") unless resource.persisted?
+      end
+    end
+  end
+end

--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -4,7 +4,9 @@ module Users
   class PasswordsController < Devise::PasswordsController
     def update
       super do |resource|
-        Rails.logger.error("Password update failed for user. Reasons: #{resource.errors.full_messages}") unless resource.persisted?
+        unless resource.persisted?
+          Rails.logger.error("Password update failed for user. Reasons: #{resource.errors.full_messages}")
+        end
       end
     end
   end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -58,6 +58,7 @@ module Users
     end
 
     def update
+      # TODO: Add validation to user update and proper error handling
       @user.update(country: params[:user][:country], city: params[:user][:city])
 
       @couch = @user.couch

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -57,16 +57,12 @@ module Users
     end
 
     def update
-      # TODO: Add validation to user update and proper error handling
-      @user.update(country_code: params[:user][:country_code], city: params[:user][:city])
-
-      @couch = @user.couch
-
-      create_couch_facilities
-
-      update_user_characteristics
-      super
-      disable_offers_if_travelling
+      super do |resource|
+        @couch = resource.couch
+        create_couch_facilities
+        update_user_characteristics
+        disable_offers_if_travelling
+      end
     end
 
     def destroy

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -98,6 +98,8 @@ module Users
       end
 
       if resource_updated
+        set_flash_message_for_update(resource, false)
+
         bypass_sign_in resource, scope: resource_name if sign_in_after_change_password?
 
         respond_with resource, location: after_update_path_for(resource)

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -84,14 +84,14 @@ module Users
       if resource.valid_password?(current_password)
         # check that the new password is valid
         resource.assign_attributes(user_params)
-        is_valid_password = resource.valid?
-        puts resource.errors.full_messages
-        if is_valid_password
-          # update the user password
-          resource_updated = resource.update_attribute(:password, user_params[:password])
-        else
-          resource_updated = false
-        end
+        is_valid_password = password_valid?
+        resource_updated = if is_valid_password
+                             # update the user password
+                             resource.update_attribute(:password, user_params[:password])
+                             resource.update_attribute(:password_confirmation, user_params[:password_confirmation])
+                           else
+                             false
+                           end
       else
         resource.errors.add(:current_password, current_password.blank? ? :blank : :invalid)
         resource_updated = false
@@ -124,6 +124,10 @@ module Users
 
     def password_update_params
       devise_parameter_sanitizer.sanitize(:password_update)
+    end
+
+    def password_valid?
+      resource.valid?(:password_update)
     end
   end
 end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -61,11 +61,12 @@ module Users
       @user.update(country: params[:user][:country], city: params[:user][:city])
 
       @couch = @user.couch
+
       create_couch_facilities
 
       update_user_characteristics
       super
-      beautify_country
+      update_profile
       disable_offers_if_travelling
     end
 

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -12,7 +12,6 @@ module Users
 
       if resource.persisted?
         create_couch
-        update_profile
         if resource.active_for_authentication?
           set_flash_message! :notice, :signed_up
           sign_up(resource_name, resource)
@@ -59,7 +58,7 @@ module Users
 
     def update
       # TODO: Add validation to user update and proper error handling
-      @user.update(country: params[:user][:country], city: params[:user][:city])
+      @user.update(country_code: params[:user][:country_code], city: params[:user][:city])
 
       @couch = @user.couch
 
@@ -67,7 +66,6 @@ module Users
 
       update_user_characteristics
       super
-      update_profile
       disable_offers_if_travelling
     end
 

--- a/app/helpers/address_helper.rb
+++ b/app/helpers/address_helper.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module AddressHelper
+  def beautify_country(country)
+    Rails.logger.info("Beautifying country: #{country}")
+    iso_country = ISO3166::Country[country]
+    translated_country = iso_country.translations[I18n.locale.to_s]
+    Rails.logger.info("Country beautification: #{country} -> #{iso_country} -> #{translated_country}")
+    raise StandardError if translated_country.nil? || translated_country == country
+
+    translated_country
+  rescue StandardError => e
+    Rails.logger.error("Error updating user profile: #{e.message}")
+    crumb = Sentry::Breadcrumb.new(
+      message: 'Error beautifying country',
+      level: 'error',
+      category: 'user',
+      data: { country:, iso_result: iso_country, translated_country:, error: e }
+    )
+    Sentry.add_breadcrumb(crumb)
+    raise ArgumentError, "Country not found: #{country}"
+  end
+
+  class Formatter
+    def self.format_address(address)
+      "#{address[:street]}, #{address[:zipcode]}, #{address[:city]}, #{address[:country]}"
+    end
+  end
+end

--- a/app/javascript/controllers/autofill_controller.js
+++ b/app/javascript/controllers/autofill_controller.js
@@ -28,7 +28,7 @@ export default class extends Controller {
     this.addressTarget.value = event.result.place_name
     const city = document.getElementById('city')
     const zip = document.getElementById('zip')
-    const country = document.getElementById('user_country')
+    const country = document.getElementById('user_country_code')
     let cityDone = false
     for (let i = 0; i < event.result.context.length; i++) {
       if (event.result.context[i].id.includes("postcode")) {

--- a/app/mailers/statistics_mailer.rb
+++ b/app/mailers/statistics_mailer.rb
@@ -129,7 +129,7 @@ class StatisticsMailer < ApplicationMailer
     successful.to_f / total_requests * 100 if total_requests.positive?
   end
 
-  def update_subscription_counters(user, total_requests, booking_requests)
+  def update_subscription_counters(_user, total_requests, booking_requests)
     if total_requests.positive?
       @total_users_with_subscription_request += 1
       @requests_subscribers += total_requests
@@ -166,7 +166,7 @@ class StatisticsMailer < ApplicationMailer
     @total_booking_requests_confirmed ||= 0
     @total_booking_requests_declined ||= 0
     @total_booking_requests_completed ||= 0
-    @total_booking_requests_expired ||= 0
+    @initialize_subscription_counters ||= 0
   end
 
   def reset_subscription_counters

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -32,7 +32,7 @@ class User < ApplicationRecord # rubocop:disable Metrics/ClassLength
   validates :address, presence: { message: 'Address required' }, on: %i[create update]
   validates :zipcode, presence: { message: 'Zipcode required' }, on: %i[create update]
   validates :city, presence: { message: 'City required' }, on: %i[create update]
-  validate :validate_country_code
+  validate :validate_country_code, on: %i[create update]
   validates :country, presence: { message: 'Country required' }, on: %i[create update]
   validates :summary, presence: { message: 'Tell the community about you' },
                       length: { minimum: 50, message: 'Tell us more about you (minimum 50 characters)' },

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -25,22 +25,23 @@ class User < ApplicationRecord # rubocop:disable Metrics/ClassLength
   has_many :characteristics, through: :user_characteristics, dependent: :destroy
   has_one :subscription, dependent: :destroy
 
-  validates :photo, presence: { message: 'Please upload a picture' }, on: :create
-  validates :first_name, presence: { message: 'First name required' }, on: :create
-  validates :last_name, presence: { message: 'Last name required' }, on: :create
-  validates :date_of_birth, presence: { message: 'Please provide your age' }, on: :create
-  validates :address, presence: { message: 'Address required' }, on: :create
-  validates :zipcode, presence: { message: 'Zipcode required' }, on: :create
-  validates :city, presence: { message: 'City required' }, on: :create
+  validates :photo, presence: { message: 'Please upload a picture' }, on: %i[create update]
+  validates :first_name, presence: { message: 'First name required' }, on: %i[create update]
+  validates :last_name, presence: { message: 'Last name required' }, on: %i[create update]
+  validates :date_of_birth, presence: { message: 'Please provide your age' }, on: %i[create update]
+  validates :address, presence: { message: 'Address required' }, on: %i[create update]
+  validates :zipcode, presence: { message: 'Zipcode required' }, on: %i[create update]
+  validates :city, presence: { message: 'City required' }, on: %i[create update]
   validate :validate_country_code
-  validates :country, presence: { message: 'Country required' }, on: :create
+  validates :country, presence: { message: 'Country required' }, on: %i[create update]
   validates :summary, presence: { message: 'Tell the community about you' },
-                      length: { minimum: 50, message: 'Tell us more about you (minimum 50 characters)' }, on: :create
-  validates_associated :characteristics, message: 'Let others know what is important to you', on: :create
-  validate :validate_user_characteristics, on: :create
-  validate :validate_age, on: :create
-  validate :validate_travelling, on: :create
-  validate :at_least_one_option_checked?, on: :create
+                      length: { minimum: 50, message: 'Tell us more about you (minimum 50 characters)' },
+                      on: %i[create update]
+  validates_associated :characteristics, message: 'Let others know what is important to you', on: %i[create update]
+  validate :validate_user_characteristics, on: %i[create update]
+  validate :validate_age, on: %i[create update]
+  validate :validate_travelling, on: %i[create update]
+  validate :at_least_one_option_checked?, on: %i[create update]
   validates :invited_by_id, on: :create, presence: { message: 'Please provide a valid invite code' }
 
   after_validation :create_stripe_reference, on: :create, unless: -> { Rails.env.test? }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -167,4 +167,15 @@ class User < ApplicationRecord # rubocop:disable Metrics/ClassLength
     Rails.logger.error(e.message)
     Sentry.capture_exception(e, extra: { address: })
   end
+
+  def reset_password(new_password, new_password_confirmation)
+    if new_password.present?
+      self.password = new_password
+      self.password_confirmation = new_password_confirmation
+      save(context: :password_update)
+    else
+      errors.add(:password, :blank)
+      false
+    end
+  end
 end

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -6,14 +6,18 @@
 		<% if user_signed_in? %>
 			<%= render "shared/navbar" %>
 			<div data-controller="dropdown-menu">
-			<% if current_user.photo.key %>
-				<%= cl_image_tag current_user.photo.key, class: 'header__avatar', alt: 'Profile picture of Quouch user', data: { dropdown_menu_target: 'toggle', action: 'click->dropdown-menu#displayAndHideMenu' } %>
-				<% if current_user.notifications.unread.count != 0 %>
-					<%= render 'shared/notifications' %>
-				<% end %>
-			<% else %>
-				<%= image_tag('https://res.cloudinary.com/dtkxl0tbk/image/upload/v1679925300/profile.jpg', class: 'header__avatar', alt: 'Example profile picture of Quouch example user', data: { dropdown_menu_target: 'toggle', action: 'click->dropdown-menu#displayAndHideMenu' } ) %>
-			<% end %>
+        <div id="dropdown_menu" class="header__menu"
+             data-dropdown-menu-target="toggle"
+             data-action="click->dropdown-menu#displayAndHideMenu">
+          <% if current_user.photo.key %>
+            <%= cl_image_tag current_user.photo.key, class: 'header__avatar', alt: 'Profile picture of Quouch user' %>
+            <% if current_user.notifications.unread.count != 0 %>
+              <%= render 'shared/notifications' %>
+            <% end %>
+          <% else %>
+            <%= image_tag('https://res.cloudinary.com/dtkxl0tbk/image/upload/v1679925300/profile.jpg', class: 'header__avatar', alt: 'Example profile picture of Quouch example user') %>
+          <% end %>
+        </div>
 				<div class="header__collapsible collapsible display-none"
 						data-dropdown-menu-target="menu">
 					<p class="collapsible__title">Hello <%= current_user.first_name %>!</p>

--- a/app/views/users/registrations/edit.html.erb
+++ b/app/views/users/registrations/edit.html.erb
@@ -139,7 +139,7 @@
           <strong>If you are cisgender but support transgender people - that’s great! But please don’t click on this filter as this is purely for transgender people to find each other and each other only</strong>
         </p>
         <% if @user.errors[:user_characteristics].any? %>
-          <%= f.error:user_characteristics, class: 'form-error form-error-characteristics' %>
+          <%= f.error :user_characteristics, class: 'form-error form-error-characteristics' %>
         <% end %>
 
         <div class="user__characteristics">

--- a/app/views/users/registrations/edit.html.erb
+++ b/app/views/users/registrations/edit.html.erb
@@ -24,7 +24,8 @@
                       error: false %>
         </div>
         <%= f.error :photo, class: 'form-error form-error-photo' %>
-        <p class="hint hint--photo">As a Quouch user, you are required to have a profile picture where your face is clearly visible.</p>
+        <p class="hint hint--photo">As a Quouch user, you are required to have a profile picture where your face is
+          clearly visible.</p>
       </div>
 
       <div class="user__info">
@@ -129,14 +130,17 @@
         <%= f.error :summary, class: 'form-error' %>
 
         <%= f.label :make_your_day %>
-        <p class="hint">What little things do you love? For example, a favorite snack, drink, or hobby item that would make your day if you would receive it.</p>
+        <p class="hint">What little things do you love? For example, a favorite snack, drink, or hobby item that would
+          make your day if you would receive it.</p>
         <%= f.input_field :passion %>
 
 
         <%= f.label :characteristics, required: true, id: 'user__characteristics-title' %>
         <p class="hint">When using the filters - think
-          <strong>"do I identify with this?”</strong> i.e. if you click “Trans Only” then you identify with being transgender.
-          <strong>If you are cisgender but support transgender people - that’s great! But please don’t click on this filter as this is purely for transgender people to find each other and each other only</strong>
+          <strong>"do I identify with this?”</strong> i.e. if you click “Trans Only” then you identify with being
+          transgender.
+          <strong>If you are cisgender but support transgender people - that’s great! But please don’t click on this
+            filter as this is purely for transgender people to find each other and each other only</strong>
         </p>
         <% if @user.errors[:user_characteristics].any? %>
           <%= f.error :user_characteristics, class: 'form-error form-error-characteristics' %>
@@ -255,21 +259,30 @@
     <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
       <p>Currently waiting confirmation for: <%= resource.unconfirmed_email %></p>
     <% end %>
+  <% end %>
 
-    <%= f.label :change_password,
-                class: 'user__password-change' %>
+</section>
+<section class="user">
+  <h1>Change password</h1>
+  <%= simple_form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put, class: 'user__form' }) do |f| %>
+    <%= f.input :old_password,
+                required: true,
+                hint: 'we need your current password to make changes',
+                input_html: { autocomplete: 'current-password' },
+                error: false %>
+    <%= f.error :old_password, class: 'password-error' %>
     <%= f.input :password,
                 hint: "leave it blank if you don't want to change it",
-                required: false,
+                required: true,
                 error: false %>
     <%= f.error :password, class: 'form-error' %>
     <%= f.input :password_confirmation,
-                required: false,
+                required: true,
                 error: false %>
     <%= f.error :password_confirmation, class: 'form-error' %>
 
     <div class="user__submit">
-      <%= f.button :submit, 'Change password' %>
+      <%= f.button :submit, 'Submit' %>
     </div>
   <% end %>
 

--- a/app/views/users/registrations/edit.html.erb
+++ b/app/views/users/registrations/edit.html.erb
@@ -245,7 +245,7 @@
                     hint: 'we need your current password to make changes',
                     input_html: { autocomplete: 'current-password' },
                     error: false %>
-        <%= f.error :current_password, class: 'form-error' %>
+        <%= f.error :current_password, class: 'password-error' %>
         <div class="user__submit">
           <%= f.button :submit, 'Update' %>
         </div>
@@ -269,7 +269,7 @@
     <%= f.error :password_confirmation, class: 'form-error' %>
 
     <div class="user__submit">
-      <%= f.button :submit, 'Update' %>
+      <%= f.button :submit, 'Change password' %>
     </div>
   <% end %>
 

--- a/app/views/users/registrations/edit.html.erb
+++ b/app/views/users/registrations/edit.html.erb
@@ -282,7 +282,7 @@
     <%= f.error :password_confirmation, class: 'form-error' %>
 
     <div class="user__submit">
-      <%= f.button :submit, 'Submit' %>
+      <%= f.button :submit, 'Confirm change' %>
     </div>
   <% end %>
 

--- a/app/views/users/registrations/edit.html.erb
+++ b/app/views/users/registrations/edit.html.erb
@@ -104,19 +104,19 @@
             <%= f.label :country,
                         required: true,
                         class: 'user__address-label' %>
-            <% if ISO3166::Country.find_country_by_iso_short_name(@user.country) != nil %>
-              <%= f.input :country,
+            <% if @user.country_code != nil %>
+              <%= f.input :country_code,
                           collection: ISO3166::Country.pluck(:iso_short_name, :alpha2).sort,
                           required: true,
                           label: false,
-                          selected: ISO3166::Country.find_country_by_iso_short_name(@user.country).alpha2 %>
+                          selected: @user.country_code %>
             <% else %>
-              <%= f.input :country,
+              <%= f.input :country_code,
                           collection: ISO3166::Country.pluck(:iso_short_name, :alpha2).sort,
                           required: true,
                           label: false %>
             <% end %>
-            <%= f.error :country, class: 'form-error' %>
+            <%= f.error :country_code, class: 'form-error' %>
           </div>
         </div>
 

--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -70,7 +70,9 @@
           <div class="user__address">
             <p class="hint">Other users will only see city & country until you officially confirm a request to host</p>
             <div class="user__address-street">
-              <%= f.label :address, class: 'user__address-label' %>
+              <%= f.label :address,
+                          required: true,
+                          class: 'user__address-label' %>
               <%= f.input :address,
                           label: false,
                           error: false,
@@ -93,7 +95,9 @@
               </div>
               <div>
                 <div class="user__address-wrap user__address-wrap--city">
-                  <%= f.label       :city, class: 'user__address-label' %>
+                  <%= f.label       :city, 
+                                    required: true,
+                                    class: 'user__address-label' %>
                   <%= f.text_field  :city,
                                     required: true,
                                     autofocus: true,
@@ -105,7 +109,9 @@
             </div>
 
             <div class="user__address-country">
-              <%= f.label :country, class: 'user__address-label' %>
+              <%= f.label :country,
+                          required: true,
+                          class: 'user__address-label' %>
               <%= f.input :country_code,
                           collection: ISO3166::Country.pluck(:iso_short_name, :alpha2).sort,
                           label: false,

--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -106,14 +106,14 @@
 
             <div class="user__address-country">
               <%= f.label :country, class: 'user__address-label' %>
-              <%= f.input :country,
+              <%= f.input :country_code,
                           collection: ISO3166::Country.pluck(:iso_short_name, :alpha2).sort,
                           label: false,
                           error: false,
                           required: true,
-                          value: params[:user]&.dig(:country) %>
+                          value: params[:user]&.dig(:country_code) %>
             </div>
-            <%= f.error   :country, class: 'form-error' %>
+            <%= f.error   :country_code, class: 'form-error' %>
           </div>
 
           <%= f.label       :about_me, required: true %>

--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -75,6 +75,7 @@
                           class: 'user__address-label' %>
               <%= f.input :address,
                           label: false,
+                          required: true,
                           error: false,
                           value: params[:user]&.dig(:address),
                           input_html: { data: { autofill_target: 'address' }, class: 'display-none' },
@@ -95,7 +96,7 @@
               </div>
               <div>
                 <div class="user__address-wrap user__address-wrap--city">
-                  <%= f.label       :city, 
+                  <%= f.label       :city,
                                     required: true,
                                     class: 'user__address-label' %>
                   <%= f.text_field  :city,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -63,7 +63,7 @@ Rails.application.routes.draw do
   mount ActionCable.server => '/cable'
   mount StripeEvent::Engine, at: '/stripe-webhooks'
 
-  devise_for :users, controllers: { registrations: 'users/registrations' }
+  devise_for :users, controllers: { registrations: 'users/registrations', passwords: 'users/passwords' }
 
   match '/404', to: 'errors#not_found', via: :all
   match '/500', to: 'errors#internal_server_error', via: :all

--- a/db/migrate/20240903054551_add_country_code_to_users.rb
+++ b/db/migrate/20240903054551_add_country_code_to_users.rb
@@ -1,0 +1,8 @@
+class AddCountryCodeToUsers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :users, :country_code, :string
+
+    # Copy the existing country column to the new country_code column, we will update all the records manually
+    User.all.each { |user| user.update_column(:country_code, user.country) }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_08_13_174944) do
+ActiveRecord::Schema[7.0].define(version: 2024_09_03_054551) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -203,6 +203,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_08_13_174944) do
     t.boolean "admin", default: false, null: false
     t.string "passion"
     t.string "jti", default: -> { "md5((random())::text)" }, null: false
+    t.string "country_code"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["invited_by_id"], name: "index_users_on_invited_by_id"
     t.index ["jti"], name: "index_users_on_jti", unique: true

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -104,6 +104,7 @@ base_user = User.new(
   address: address[:address],
   zipcode: address[:zipcode],
   city: address[:city],
+  country_code: 'DE',
   country: address[:country]
 )
 

--- a/test/controllers/concerns/couches_concern_test.rb
+++ b/test/controllers/concerns/couches_concern_test.rb
@@ -68,8 +68,8 @@ class CouchesConcernTest < ActiveSupport::TestCase
 
   test 'should search by country' do
     # Create at least one couch
-    @host = FactoryBot.create(:user, :for_test, :with_couch, country: 'Canada')
-    @host.country = 'Canada'
+    @host = FactoryBot.create(:user, :for_test, :with_couch)
+    @host.country_code = 'CA'
     @host.save!
 
     # Filter by country

--- a/test/controllers/concerns/couches_concern_test.rb
+++ b/test/controllers/concerns/couches_concern_test.rb
@@ -169,6 +169,7 @@ class CouchesConcernTest < ActiveSupport::TestCase
 
     @host2 = FactoryBot.create(:user, :for_test, :with_couch)
     @host2.offers_couch = false
+    @host2.offers_hang_out = true
     @host2.save!
 
     # Set up necessary conditions for the offers filter
@@ -214,6 +215,7 @@ class CouchesConcernTest < ActiveSupport::TestCase
 
     @host3 = FactoryBot.create(:user, :for_test, :with_couch)
     @host3.offers_couch = false
+    @host3.offers_hang_out = true
     @host3.save!
 
     # Add characteristic to two hosts
@@ -276,6 +278,7 @@ class CouchesConcernTest < ActiveSupport::TestCase
 
     @host3 = FactoryBot.create(:user, :for_test, :with_couch)
     @host3.offers_couch = false
+    @host3.offers_hang_out = true
     @host3.city = 'Test City'
     @host3.save!
 

--- a/test/controllers/concerns/registration_concern_test.rb
+++ b/test/controllers/concerns/registration_concern_test.rb
@@ -8,7 +8,8 @@ class RegistrationConcernTest < ActiveSupport::TestCase
   setup do
     create_seed_user
 
-    @user = FactoryBot.create(:user)
+    @user = FactoryBot.create(:user, :with_couch, :for_test)
+    @couch = @user.couch
   end
 
   ADDRESSES.each_with_index do |address, index|
@@ -83,5 +84,54 @@ class RegistrationConcernTest < ActiveSupport::TestCase
     update_profile
     @user.reload
     assert_equal 'Germany', @user.country
+  end
+
+  test 'should raise an error if facilities are empty' do
+    params[:couch_facility] = {
+      facility_ids: []
+    }
+
+    assert_raise(ArgumentError) { create_couch_facilities }
+
+    params[:couch_facility] = {
+      facility_ids: ['']
+    }
+
+    assert_raise(ArgumentError) { create_couch_facilities }
+  end
+
+  test 'should save couch facilities' do
+    facility = Facility.first
+    params[:couch_facility] = {
+      facility_ids: [facility.id.to_s]
+    }
+
+    create_couch_facilities
+    assert_equal 1, @couch.couch_facilities.count
+  end
+
+  test 'should not save empty couch facilities' do
+    facility = Facility.first
+    params[:couch_facility] = {
+      facility_ids: ['', facility.id.to_s]
+    }
+
+    create_couch_facilities
+    assert_equal 1, @couch.couch_facilities.count
+  end
+
+  test 'should remove couch facilities' do
+    facility = Facility.first
+    params[:couch_facility] = {
+      facility_ids: [facility.id.to_s]
+    }
+
+    create_couch_facilities
+    assert_equal 1, @couch.couch_facilities.count
+
+    params[:couch_facility] = {}
+
+    create_couch_facilities
+    assert_equal 0, @couch.couch_facilities.count
   end
 end

--- a/test/controllers/concerns/registration_concern_test.rb
+++ b/test/controllers/concerns/registration_concern_test.rb
@@ -12,37 +12,6 @@ class RegistrationConcernTest < ActiveSupport::TestCase
     @couch = @user.couch
   end
 
-  ADDRESSES.each_with_index do |address, index|
-    define_method "test_should_beautify_address_#{index}" do
-      params[:user] = {
-        country: address[:country_code]
-      }
-
-      assert_equal address[:country], beautify_country, "Address #{address[:address]} failed"
-    end
-  end
-
-  test 'should throw an error if the country is not found' do
-    params[:user] = {
-      country: 'XX'
-    }
-
-    assert_raise(ArgumentError) { beautify_country }
-  end
-
-  test 'should throw an error if the country cannot be translated' do
-    issue_countries_in_db = %w[DE NL FI US AT FR NO]
-
-    issue_countries_in_db.each do |country_code|
-      params[:user] = {
-        country: country_code
-      }
-
-      # Assert that no errors are thrown for the countries in the list
-      assert_nothing_raised { beautify_country }
-    end
-  end
-
   test 'should find the user ID by invite code' do
     other_user = FactoryBot.create(:user)
     invite_code = other_user.invite_code
@@ -76,17 +45,8 @@ class RegistrationConcernTest < ActiveSupport::TestCase
     assert_equal other_user.id, found_id
   end
 
-  test 'should update the user profile with beautified country' do
-    params[:user] = {
-      country: 'DE'
-    }
-
-    update_profile
-    @user.reload
-    assert_equal 'Germany', @user.country
-  end
-
   test 'should raise an error if facilities are empty' do
+    skip "This test is not implemented yet. Issues are not raised since they can't be handled in the current implementation."
     params[:couch_facility] = {
       facility_ids: []
     }

--- a/test/factories/users.rb
+++ b/test/factories/users.rb
@@ -29,10 +29,10 @@ FactoryBot.define do
       user.photo.attach(io: file, filename: 'avatar.png', content_type: 'image/png')
 
       random_address = ADDRESSES.sample
-      user.address = AddressHelper.format_address(random_address)
+      user.address = AddressHelper::Formatter.format_address(random_address)
       user.zipcode = random_address[:zipcode]
       user.city = random_address[:city]
-      user.country = random_address[:country]
+      user.country_code = random_address[:country_code]
     end
 
     trait :skip_validation do

--- a/test/fixtures/facilities.yml
+++ b/test/fixtures/facilities.yml
@@ -1,0 +1,11 @@
+couch:
+  id: 1
+  name: couch
+
+bed:
+  id: 2
+  name: bed
+
+extra_key:
+  id: 3
+  name: extra key

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -12,9 +12,11 @@ user_<%= n %>:
   offers_co_work: <%= true %>
   offers_hang_out: <%= true %>
   travelling: <%= true %>
+
   address: <%= Faker::Address.full_address %>
   city: <%= Faker::Address.city %>
   zipcode: <%= Faker::Address.zip_code %>
+  country_code: <%= Faker::Address.country_code %>
   country: <%= Faker::Address.country %>
   created_at: <%= Time.now %>
   updated_at: <%= Time.now %>
@@ -32,5 +34,6 @@ manual:
   address: <%= Faker::Address.full_address %>
   city: <%= Faker::Address.city %>
   zipcode: <%= Faker::Address.zip_code %>
+  country_code: <%= Faker::Address.country_code %>
   country: <%= Faker::Address.country %>
   invited_by_id: 1

--- a/test/helpers/address_helper_test.rb
+++ b/test/helpers/address_helper_test.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class AddressHelperTest < ActiveSupport::TestCase
+  include AddressHelper
+
+  ADDRESSES.each_with_index do |address, index|
+    define_method "test_should_beautify_address_#{index}" do
+      country = address[:country_code]
+
+      assert_equal address[:country], beautify_country(country), "Address #{address[:address]} failed"
+    end
+  end
+
+  test 'should throw an error if the country is not found' do
+    country = 'XX'
+
+    assert_raise(ArgumentError) { beautify_country(country) }
+  end
+
+  test 'should throw an error if the country cannot be translated' do
+    issue_countries_in_db = %w[DE NL FI US AT FR NO]
+
+    issue_countries_in_db.each do |country_code|
+      # Assert that no errors are thrown for the countries in the list
+      assert_nothing_raised { beautify_country(country_code) }
+    end
+  end
+
+  test 'should format address' do
+    address = { street: 'Main Street', zipcode: '12345', city: 'Springfield', country: 'US' }
+    formatted_address = AddressHelper::Formatter.format_address(address)
+    assert_equal 'Main Street, 12345, Springfield, US', formatted_address
+  end
+end

--- a/test/helpers/addresses.rb
+++ b/test/helpers/addresses.rb
@@ -1,11 +1,5 @@
 # frozen_string_literal: true
 
-class AddressHelper
-  def self.format_address(address)
-    "#{address[:street]}, #{address[:zipcode]}, #{address[:city]}, #{address[:country]}"
-  end
-end
-
 ADDRESSES = [
   { street: '123 Main St', city: 'New York', country: 'United States', zipcode: '10001', country_code: 'US' },
   { street: '456 Market St', city: 'San Francisco', country: 'United States', zipcode: '94105', country_code: 'US' },

--- a/test/helpers/user_helper.rb
+++ b/test/helpers/user_helper.rb
@@ -15,7 +15,7 @@ module UserHelper
       first_name: Faker::Name.first_name,
       last_name: Faker::Name.last_name,
       confirmed_at: Time.now,
-      address: AddressHelper.format_address(random_address),
+      address: AddressHelper::Formatter.format_address(random_address),
       zipcode: random_address[:zipcode],
       city: random_address[:city],
       country: random_address[:country],

--- a/test/integration/controllers/users/passwords_controller_test.rb
+++ b/test/integration/controllers/users/passwords_controller_test.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class PasswordsControllerTest < ActionDispatch::IntegrationTest
+  include Devise::Test::IntegrationHelpers
+
+  def setup
+    @user = FactoryBot.create(:user, :for_test, :with_couch)
+  end
+
+  test 'should reset forgotten password' do
+    post user_password_url, params: { user: { email: @user.email } }
+    assert_response :redirect
+    follow_redirect!
+    assert_response :success
+
+    assert_includes flash[:notice],
+                    'You will receive an email with instructions on how to reset your password in a few minutes.'
+
+    reset_token = ActionMailer::Base.deliveries.last.body.match(/reset_password_token=(.*)"/)[1]
+
+    patch user_password_path,
+          params: { user: { password: 'newpassword', password_confirmation: 'newpassword',
+                            reset_password_token: reset_token } }
+
+    assert_response :redirect
+
+    assert @user.reload.valid_password?('newpassword')
+  end
+
+  test 'should not reset forgotten password with invalid token' do
+    post user_password_url, params: { user: { email: @user.email } }
+    assert_response :redirect
+    follow_redirect!
+    assert_response :success
+
+    assert_includes flash[:notice],
+                    'You will receive an email with instructions on how to reset your password in a few minutes.'
+
+    patch user_password_path,
+          params: { user: { password: 'newpassword', password_confirmation: 'newpassword',
+                            reset_password_token: 'invalidtoken' } }
+
+    assert_response :unprocessable_entity
+
+    assert_not @user.reload.valid_password?('newpassword')
+  end
+
+  test 'should reset forgotten password even if user is invalid' do
+    # Make the user invalid
+    @user.update_attribute(:last_name, nil)
+
+    post user_password_url, params: { user: { email: @user.email } }
+    assert_response :redirect
+    follow_redirect!
+    assert_response :success
+
+    assert_includes flash[:notice],
+                    'You will receive an email with instructions on how to reset your password in a few minutes.'
+
+    reset_token = ActionMailer::Base.deliveries.last.body.match(/reset_password_token=(.*)"/)[1]
+
+    patch user_password_path,
+          params: { user: { password: 'newpassword', password_confirmation: 'newpassword',
+                            reset_password_token: reset_token } }
+
+    assert_response :redirect
+
+    assert @user.reload.valid_password?('newpassword')
+  end
+end

--- a/test/integration/controllers/users/passwords_controller_test.rb
+++ b/test/integration/controllers/users/passwords_controller_test.rb
@@ -2,71 +2,73 @@
 
 require 'test_helper'
 
-class PasswordsControllerTest < ActionDispatch::IntegrationTest
-  include Devise::Test::IntegrationHelpers
+module Users
+  class PasswordsControllerTest < ActionDispatch::IntegrationTest
+    include Devise::Test::IntegrationHelpers
 
-  def setup
-    @user = FactoryBot.create(:user, :for_test, :with_couch)
-  end
+    def setup
+      @user = FactoryBot.create(:user, :for_test, :with_couch)
+    end
 
-  test 'should reset forgotten password' do
-    post user_password_url, params: { user: { email: @user.email } }
-    assert_response :redirect
-    follow_redirect!
-    assert_response :success
+    test 'should reset forgotten password' do
+      post user_password_url, params: { user: { email: @user.email } }
+      assert_response :redirect
+      follow_redirect!
+      assert_response :success
 
-    assert_includes flash[:notice],
-                    'You will receive an email with instructions on how to reset your password in a few minutes.'
+      assert_includes flash[:notice],
+                      'You will receive an email with instructions on how to reset your password in a few minutes.'
 
-    reset_token = ActionMailer::Base.deliveries.last.body.match(/reset_password_token=(.*)"/)[1]
+      reset_token = ActionMailer::Base.deliveries.last.body.match(/reset_password_token=(.*)"/)[1]
 
-    patch user_password_path,
-          params: { user: { password: 'newpassword', password_confirmation: 'newpassword',
-                            reset_password_token: reset_token } }
+      patch user_password_path,
+            params: { user: { password: 'newpassword', password_confirmation: 'newpassword',
+                              reset_password_token: reset_token } }
 
-    assert_response :redirect
+      assert_response :redirect
 
-    assert @user.reload.valid_password?('newpassword')
-  end
+      assert @user.reload.valid_password?('newpassword')
+    end
 
-  test 'should not reset forgotten password with invalid token' do
-    post user_password_url, params: { user: { email: @user.email } }
-    assert_response :redirect
-    follow_redirect!
-    assert_response :success
+    test 'should not reset forgotten password with invalid token' do
+      post user_password_url, params: { user: { email: @user.email } }
+      assert_response :redirect
+      follow_redirect!
+      assert_response :success
 
-    assert_includes flash[:notice],
-                    'You will receive an email with instructions on how to reset your password in a few minutes.'
+      assert_includes flash[:notice],
+                      'You will receive an email with instructions on how to reset your password in a few minutes.'
 
-    patch user_password_path,
-          params: { user: { password: 'newpassword', password_confirmation: 'newpassword',
-                            reset_password_token: 'invalidtoken' } }
+      patch user_password_path,
+            params: { user: { password: 'newpassword', password_confirmation: 'newpassword',
+                              reset_password_token: 'invalidtoken' } }
 
-    assert_response :unprocessable_entity
+      assert_response :unprocessable_entity
 
-    assert_not @user.reload.valid_password?('newpassword')
-  end
+      assert_not @user.reload.valid_password?('newpassword')
+    end
 
-  test 'should reset forgotten password even if user is invalid' do
-    # Make the user invalid
-    @user.update_attribute(:last_name, nil)
+    test 'should reset forgotten password even if user is invalid' do
+      # Make the user invalid
+      @user.update_attribute(:last_name, nil)
 
-    post user_password_url, params: { user: { email: @user.email } }
-    assert_response :redirect
-    follow_redirect!
-    assert_response :success
+      post user_password_url, params: { user: { email: @user.email } }
+      assert_response :redirect
+      follow_redirect!
+      assert_response :success
 
-    assert_includes flash[:notice],
-                    'You will receive an email with instructions on how to reset your password in a few minutes.'
+      assert_includes flash[:notice],
+                      'You will receive an email with instructions on how to reset your password in a few minutes.'
 
-    reset_token = ActionMailer::Base.deliveries.last.body.match(/reset_password_token=(.*)"/)[1]
+      reset_token = ActionMailer::Base.deliveries.last.body.match(/reset_password_token=(.*)"/)[1]
 
-    patch user_password_path,
-          params: { user: { password: 'newpassword', password_confirmation: 'newpassword',
-                            reset_password_token: reset_token } }
+      patch user_password_path,
+            params: { user: { password: 'newpassword', password_confirmation: 'newpassword',
+                              reset_password_token: reset_token } }
 
-    assert_response :redirect
+      assert_response :redirect
 
-    assert @user.reload.valid_password?('newpassword')
+      assert @user.reload.valid_password?('newpassword')
+    end
   end
 end

--- a/test/integration/controllers/users/registrations_controller_test.rb
+++ b/test/integration/controllers/users/registrations_controller_test.rb
@@ -76,5 +76,82 @@ module Users
 
       assert_not_nil User.last.invited_by_id
     end
+
+    test 'should beautify the country on update' do
+      # First, create a user
+      user_data = create_user_and_sign_in
+
+      # Send the user with a country code instead of the country name
+      user_data['country'] = 'IT'
+      patch user_registration_url,
+            params: { user: user_data,
+                      user_characteristic: { characteristic_ids: [Characteristic.first.id] }
+            }
+
+      assert_equal 'Italy', User.last.country
+    end
+
+    test 'should save couch facilities' do
+      # First, create a user
+      user_data = create_user_and_sign_in
+
+      # Update the user with facilities
+      patch user_registration_url,
+            params: { user: user_data,
+                      user_characteristic: { characteristic_ids: [Characteristic.first.id] },
+                      couch_facility: { facility_ids: [Facility.first.id] }
+            }
+
+      assert_equal 1, User.last.couch.couch_facilities.count
+    end
+
+    test 'should save user without facilities' do
+      # First, create a user
+      user_data = create_user_and_sign_in
+
+      user_data['offers_couch'] = false
+      patch user_registration_url,
+            params: { user: user_data,
+                      user_characteristic: { characteristic_ids: [Characteristic.first.id] }
+            }
+
+      assert_equal 0, User.last.couch.couch_facilities.count
+    end
+
+    test 'should remove couch facilities' do
+      # First, create a user
+      user_data = create_user_and_sign_in
+
+      # Update the user with facilities
+      patch user_registration_url,
+            params: { user: user_data,
+                      user_characteristic: { characteristic_ids: [Characteristic.first.id] },
+                      couch_facility: { facility_ids: [Facility.first.id] }
+            }
+
+      assert_equal 1, User.last.couch.couch_facilities.count
+
+      # Update the user without facilities and check if the facilities are removed
+      user_data['offers_couch'] = false
+      patch user_registration_url,
+            params: { user: user_data,
+                      user_characteristic: { characteristic_ids: [Characteristic.first.id] }
+            }
+
+      assert_equal 0, User.last.couch.couch_facilities.count
+    end
+
+    private
+
+    def create_user_and_sign_in
+      # First, create a user
+      user = FactoryBot.create(:user, :for_test, :with_couch)
+      sign_in user
+
+      user_data = user.attributes
+      user_data['country'] = 'DE' # Send the user with a country code instead of the country name
+
+      user_data
+    end
   end
 end

--- a/test/integration/controllers/users/registrations_controller_test.rb
+++ b/test/integration/controllers/users/registrations_controller_test.rb
@@ -227,7 +227,7 @@ module Users
       create_user_and_sign_in
 
       password_data = {
-        password: 'a',
+        password: 'strongpassword',
         password_confirmation: 'b',
         old_password: @user.password
       }

--- a/test/integration/controllers/users/registrations_controller_test.rb
+++ b/test/integration/controllers/users/registrations_controller_test.rb
@@ -77,6 +77,19 @@ module Users
       assert_not_nil User.last.invited_by_id
     end
 
+    test 'should update the user' do
+      # First, create a user
+      user_data = create_user_and_sign_in
+
+      # Send the user with a country code instead of the country name
+      user_data['first_name'] = 'New name'
+      patch user_registration_url,
+            params: { user: user_data,
+                      user_characteristic: { characteristic_ids: [Characteristic.first.id] } }
+
+      assert_equal 'New name', User.last.first_name
+    end
+
     test 'should beautify the country on update' do
       # First, create a user
       user_data = create_user_and_sign_in
@@ -85,6 +98,7 @@ module Users
       user_data['country_code'] = 'IT'
       patch user_registration_url,
             params: { user: user_data,
+                      password: @user.password,
                       user_characteristic: { characteristic_ids: [Characteristic.first.id] } }
 
       assert_equal 'Italy', User.last.country
@@ -154,10 +168,12 @@ module Users
 
     def create_user_and_sign_in
       # First, create a user
-      user = FactoryBot.create(:user, :for_test, :with_couch)
-      sign_in user
+      @user = FactoryBot.create(:user, :for_test, :with_couch)
+      sign_in @user
 
-      user.attributes
+      user_data = @user.attributes
+      user_data['current_password'] = @user.password
+      user_data
     end
   end
 end

--- a/test/integration/controllers/users/registrations_controller_test.rb
+++ b/test/integration/controllers/users/registrations_controller_test.rb
@@ -19,10 +19,10 @@ module Users
         date_of_birth: fake_user_data[:date_of_birth],
         summary: fake_user_data[:summary],
         offers_couch: true,
-        address: AddressHelper.format_address(random_address),
+        address: AddressHelper::Formatter.format_address(random_address),
         zipcode: random_address[:zipcode],
         city: random_address[:city],
-        country: random_address[:country_code],
+        country_code: random_address[:country_code],
         photo:
       }
     end
@@ -82,7 +82,7 @@ module Users
       user_data = create_user_and_sign_in
 
       # Send the user with a country code instead of the country name
-      user_data['country'] = 'IT'
+      user_data['country_code'] = 'IT'
       patch user_registration_url,
             params: { user: user_data,
                       user_characteristic: { characteristic_ids: [Characteristic.first.id] } }
@@ -157,10 +157,7 @@ module Users
       user = FactoryBot.create(:user, :for_test, :with_couch)
       sign_in user
 
-      user_data = user.attributes
-      user_data['country'] = 'DE' # Send the user with a country code instead of the country name
-
-      user_data
+      user.attributes
     end
   end
 end

--- a/test/integration/controllers/users/registrations_controller_test.rb
+++ b/test/integration/controllers/users/registrations_controller_test.rb
@@ -85,8 +85,7 @@ module Users
       user_data['country'] = 'IT'
       patch user_registration_url,
             params: { user: user_data,
-                      user_characteristic: { characteristic_ids: [Characteristic.first.id] }
-            }
+                      user_characteristic: { characteristic_ids: [Characteristic.first.id] } }
 
       assert_equal 'Italy', User.last.country
     end
@@ -99,10 +98,23 @@ module Users
       patch user_registration_url,
             params: { user: user_data,
                       user_characteristic: { characteristic_ids: [Characteristic.first.id] },
-                      couch_facility: { facility_ids: [Facility.first.id] }
-            }
+                      couch_facility: { facility_ids: [Facility.first.id] } }
 
       assert_equal 1, User.last.couch.couch_facilities.count
+    end
+
+    test 'should throw error if facilities are empty' do
+      skip 'This test is failing because we do not have a validation for user updates.'
+      # First, create a user
+      user_data = create_user_and_sign_in
+
+      # Update the user with facilities
+      patch user_registration_url,
+            params: { user: user_data,
+                      user_characteristic: { characteristic_ids: [Characteristic.first.id] },
+                      couch_facility: { facility_ids: [] } }
+
+      assert_includes flash[:error], 'Please select at least one facility.'
     end
 
     test 'should save user without facilities' do
@@ -112,8 +124,7 @@ module Users
       user_data['offers_couch'] = false
       patch user_registration_url,
             params: { user: user_data,
-                      user_characteristic: { characteristic_ids: [Characteristic.first.id] }
-            }
+                      user_characteristic: { characteristic_ids: [Characteristic.first.id] } }
 
       assert_equal 0, User.last.couch.couch_facilities.count
     end
@@ -126,8 +137,7 @@ module Users
       patch user_registration_url,
             params: { user: user_data,
                       user_characteristic: { characteristic_ids: [Characteristic.first.id] },
-                      couch_facility: { facility_ids: [Facility.first.id] }
-            }
+                      couch_facility: { facility_ids: [Facility.first.id] } }
 
       assert_equal 1, User.last.couch.couch_facilities.count
 
@@ -135,8 +145,7 @@ module Users
       user_data['offers_couch'] = false
       patch user_registration_url,
             params: { user: user_data,
-                      user_characteristic: { characteristic_ids: [Characteristic.first.id] }
-            }
+                      user_characteristic: { characteristic_ids: [Characteristic.first.id] } }
 
       assert_equal 0, User.last.couch.couch_facilities.count
     end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -39,8 +39,35 @@ class UserTest < ActiveSupport::TestCase
   end
 
   test 'should not save user without a country' do
+    @user.country_code = nil
     @user.country = nil
     assert_not @user.valid?
+    assert_equal @user.errors.messages[:country], ['Country required']
+    assert_equal @user.errors.messages[:country_code], ['Please provide a valid country code']
+  end
+
+  test 'should calculate the country based on the country_code' do
+    @user.country_code = 'DE'
+    @user.country = nil
+
+    assert @user.valid?
+    assert_equal 'Germany', @user.country
+  end
+
+  test 'should fail if the country code is not an ISO code' do
+    @user.country_code = 'DEU'
+    @user.country = nil
+
+    assert_not @user.valid?
+    assert_equal @user.errors.messages[:country_code], ['Please provide a valid country code']
+  end
+
+  test 'should overwrite the country if both are present' do
+    @user.country_code = 'DE'
+    @user.country = 'Deutschland'
+
+    assert @user.valid?
+    assert_equal 'Germany', @user.country
   end
 
   test 'should not save user without a summary' do

--- a/test/system/users/login_test.rb
+++ b/test/system/users/login_test.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require 'system_test_helper'
+
+module Users
+  class LoginTest < ApplicationSystemTestCase
+    def setup
+      @login_user = FactoryBot.create(:user, :for_test, :with_couch)
+    end
+
+    test 'should log in successfully' do
+      visit root_path
+
+      click_on 'Log in'
+
+      fill_in 'Email Address', with: @login_user.email
+      fill_in 'Password', with: @login_user.password
+
+      # There are two log in buttons, one is a link and the other one is an input.
+      # We want to click on the input one.
+      find('input[type="submit"]').click
+
+      assert_selector 'div.flash', text: 'Signed in successfully.'
+    end
+
+    test 'should not log in with invalid credentials' do
+      visit root_path
+
+      click_on 'Log in'
+
+      fill_in 'Email Address', with: @login_user.email
+      fill_in 'Password', with: 'invalid_password'
+
+      # There are two log in buttons, one is a link and the other one is an input.
+      # We want to click on the input one.
+      find('input[type="submit"]').click
+
+      assert_selector 'div.flash', text: 'Invalid Email or password.'
+    end
+  end
+end

--- a/test/system/users/password_reset_test.rb
+++ b/test/system/users/password_reset_test.rb
@@ -1,0 +1,88 @@
+require 'system_test_helper'
+
+module Users
+  class PasswordResetTest < ApplicationSystemTestCase
+    include ActionMailer::TestHelper
+
+    def setup
+      @reset_user = FactoryBot.create(:user, :for_test, :with_couch)
+    end
+
+    test 'should not reset password with invalid email' do
+      visit new_user_session_path
+
+      click_on 'Forgot your password?'
+
+      fill_in 'Email Address', with: 'notanemail@example.com'
+
+      find('input[type="submit"]').click
+
+      assert_selector '.form_error', text: 'not found'
+    end
+
+    test 'should reset password' do
+      visit new_user_session_path
+
+      click_on 'Forgot your password?'
+
+      fill_in 'Email Address', with: @reset_user.email
+
+      submit_and_open_reset_link
+
+      new_password = 'newpassword'
+      fill_in 'New password', with: new_password
+      fill_in 'Confirm your new password', with: new_password
+
+      find('input[type="submit"]').click
+
+      assert_selector 'div.flash', text: 'Your password has been changed successfully.'
+
+      assert @reset_user.reload.valid_password?(new_password)
+    end
+
+    test 'should reset password even if user is invalid' do
+      # Make the user invalid
+      @reset_user.first_name = ''
+      @reset_user.save!(validate: false)
+
+      visit new_user_session_path
+
+      click_on 'Forgot your password?'
+
+      fill_in 'Email Address', with: @reset_user.email
+
+      submit_and_open_reset_link
+
+      new_password = 'newpassword'
+      fill_in 'New password', with: new_password
+      fill_in 'Confirm your new password', with: new_password
+
+      find('input[type="submit"]').click
+
+      assert_selector 'div.flash', text: 'Your password has been changed successfully.'
+
+      assert @reset_user.reload.valid_password?(new_password)
+    end
+
+    private
+
+    def submit_and_open_reset_link
+      assert_emails 1 do
+        find('input[type="submit"]').click
+      end
+
+      assert_selector 'div.flash',
+                      text: 'You will receive an email with instructions on how to reset your password in a few minutes.'
+
+      # Get the reset password link
+      sent_email = ActionMailer::Base.deliveries.last
+      reset_password_link = sent_email.body.to_s.match(/href="(?<reset_link>.+?)"/)[:reset_link]
+
+      # Remove the localhost part of the link
+      reset_password_link = reset_password_link.gsub('http://localhost:3000', '')
+      visit reset_password_link
+
+      assert_selector 'h2', text: 'Change Password'.upcase
+    end
+  end
+end

--- a/test/system/users/profile_edit_workflow_test.rb
+++ b/test/system/users/profile_edit_workflow_test.rb
@@ -67,6 +67,30 @@ class ProfileEditWorkflowTest < ApplicationSystemTestCase
     assert_selector '.form_error', text: 'Last name required'
   end
 
+  test 'should not change the password if clicks on wrong button' do
+    visit edit_user_registration_path
+
+    fill_in 'user[password]', with: 'new_password'
+    fill_in 'user[password_confirmation]', with: 'new_password'
+    submit_form
+
+    # The password should not be updated
+    assert @editing_user.reload.valid_password?(@editing_user.password)
+  end
+
+  test'should change the password' do
+    visit edit_user_registration_path
+
+    fill_in 'user[password]', with: 'new_password'
+    fill_in 'user[password_confirmation]', with: 'new_password'
+    fill_in 'user[old_password]', with: @editing_user.password
+
+    click_on 'Submit'
+
+    assert_selector 'div.flash', text: 'Your account has been updated successfully.'
+    assert_current_path root_path
+    assert @editing_user.reload.valid_password?('new_password')
+  end
   private
 
   def submit_form

--- a/test/system/users/profile_edit_workflow_test.rb
+++ b/test/system/users/profile_edit_workflow_test.rb
@@ -78,7 +78,7 @@ class ProfileEditWorkflowTest < ApplicationSystemTestCase
     assert @editing_user.reload.valid_password?(@editing_user.password)
   end
 
-  test'should change the password' do
+  test 'should change the password' do
     visit edit_user_registration_path
 
     fill_in 'user[password]', with: 'new_password'
@@ -91,6 +91,7 @@ class ProfileEditWorkflowTest < ApplicationSystemTestCase
     assert_current_path root_path
     assert @editing_user.reload.valid_password?('new_password')
   end
+
   private
 
   def submit_form

--- a/test/system/users/profile_edit_workflow_test.rb
+++ b/test/system/users/profile_edit_workflow_test.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require 'system_test_helper'
+
+class ProfileEditWorkflowTest < ApplicationSystemTestCase
+  def setup
+    @inviting_user = FactoryBot.create(:user, :for_test, :with_couch)
+
+    @editing_user = FactoryBot.create(:user, :for_test, :with_couch)
+
+    sign_in_as(@editing_user)
+  end
+
+  test 'should open edit page' do
+    visit edit_user_registration_path
+
+    assert_selector 'h1', text: 'Edit profile'.upcase
+  end
+
+  test 'should navigate to edit page' do
+    visit root_path
+
+    find('#dropdown_menu').click
+    click_on 'Edit Profile'
+
+    assert_selector 'h1', text: 'Edit profile'.upcase
+  end
+
+  test 'should have user information prefilled' do
+    visit edit_user_registration_path
+
+    assert_field 'user[first_name]', with: @editing_user[:first_name]
+    assert_field 'user[last_name]', with: @editing_user[:last_name]
+    assert_field 'user[email]', with: @editing_user[:email]
+    assert_field 'user[summary]', with: @editing_user[:summary]
+    assert_field 'user[zipcode]', with: @editing_user[:zipcode]
+    assert_field 'user[city]', with: @editing_user[:city]
+    assert_field 'user[country_code]', with: @editing_user[:country_code]
+  end
+
+  test 'should not save without password input' do
+    visit edit_user_registration_path
+
+    fill_in 'user[first_name]', with: 'New name'
+    click_on 'Update'
+
+    assert_selector '.password-error', text: 'can\'t be blank'
+  end
+
+  test 'should update and redirect to home page' do
+    visit edit_user_registration_path
+
+    fill_in 'user[first_name]', with: 'New name'
+    submit_form
+
+    assert_selector 'div.flash', text: 'Your account has been updated successfully.'
+    assert_current_path root_path
+  end
+
+  test 'should present errors in form' do
+    visit edit_user_registration_path
+
+    fill_in 'user[last_name]', with: ''
+    submit_form
+
+    assert_no_current_path root_path
+    assert_selector '.form_error', text: 'Last name required'
+  end
+
+  private
+
+  def submit_form
+    fill_in 'user[current_password]', with: @editing_user.password
+    click_on 'Update'
+  end
+end

--- a/test/system/users/profile_edit_workflow_test.rb
+++ b/test/system/users/profile_edit_workflow_test.rb
@@ -2,100 +2,121 @@
 
 require 'system_test_helper'
 
-class ProfileEditWorkflowTest < ApplicationSystemTestCase
-  def setup
-    @inviting_user = FactoryBot.create(:user, :for_test, :with_couch)
+module Users
+  class ProfileEditWorkflowTest < ApplicationSystemTestCase
+    def setup
+      @editing_user = FactoryBot.create(:user, :for_test, :with_couch)
 
-    @editing_user = FactoryBot.create(:user, :for_test, :with_couch)
+      sign_in_as(@editing_user)
+    end
 
-    sign_in_as(@editing_user)
+    test 'should open edit page' do
+      visit edit_user_registration_path
+
+      assert_selector 'h1', text: 'Edit profile'.upcase
+    end
+
+    test 'should navigate to edit page' do
+      visit root_path
+
+      find('#dropdown_menu').click
+      click_on 'Edit Profile'
+
+      assert_selector 'h1', text: 'Edit profile'.upcase
+    end
+
+    test 'should have user information prefilled' do
+      visit edit_user_registration_path
+
+      assert_field 'user[first_name]', with: @editing_user[:first_name]
+      assert_field 'user[last_name]', with: @editing_user[:last_name]
+      assert_field 'user[email]', with: @editing_user[:email]
+      assert_field 'user[summary]', with: @editing_user[:summary]
+      assert_field 'user[zipcode]', with: @editing_user[:zipcode]
+      assert_field 'user[city]', with: @editing_user[:city]
+      assert_field 'user[country_code]', with: @editing_user[:country_code]
+    end
+
+    test 'should not save without password input' do
+      visit edit_user_registration_path
+
+      fill_in 'user[first_name]', with: 'New name'
+      click_on 'Update'
+
+      assert_selector '.password-error', text: 'can\'t be blank'
+    end
+
+    test 'should update and redirect to home page' do
+      visit edit_user_registration_path
+
+      fill_in 'user[first_name]', with: 'New name'
+      submit_form
+
+      assert_selector 'div.flash', text: 'Your account has been updated successfully.'
+      assert_current_path root_path
+    end
+
+    test 'should present errors in form' do
+      visit edit_user_registration_path
+
+      fill_in 'user[last_name]', with: ''
+      submit_form
+
+      assert_no_current_path root_path
+      assert_selector '.form_error', text: 'Last name required'
+    end
+
+    test 'should not change the password if clicks on wrong button' do
+      visit edit_user_registration_path
+
+      fill_in 'user[password]', with: 'new_password'
+      fill_in 'user[password_confirmation]', with: 'new_password'
+      submit_form
+
+      # The password should not be updated
+      assert @editing_user.reload.valid_password?(@editing_user.password)
+    end
+
+    private
+
+    def submit_form
+      fill_in 'user[current_password]', with: @editing_user.password
+      click_on 'Update'
+    end
   end
 
-  test 'should open edit page' do
-    visit edit_user_registration_path
+  class PasswordChangeTest < ApplicationSystemTestCase
+    def setup
+      @editing_user = FactoryBot.create(:user, :for_test, :with_couch)
 
-    assert_selector 'h1', text: 'Edit profile'.upcase
-  end
+      sign_in_as(@editing_user)
+    end
 
-  test 'should navigate to edit page' do
-    visit root_path
+    test 'should change the password' do
+      visit edit_user_registration_path
 
-    find('#dropdown_menu').click
-    click_on 'Edit Profile'
+      fill_in 'user[password]', with: 'new_password'
+      fill_in 'user[password_confirmation]', with: 'new_password'
+      fill_in 'user[old_password]', with: @editing_user.password
 
-    assert_selector 'h1', text: 'Edit profile'.upcase
-  end
+      click_on 'Confirm change'
 
-  test 'should have user information prefilled' do
-    visit edit_user_registration_path
+      assert_selector 'div.flash', text: 'Your account has been updated successfully.'
+      assert_current_path root_path
+      assert @editing_user.reload.valid_password?('new_password')
+    end
 
-    assert_field 'user[first_name]', with: @editing_user[:first_name]
-    assert_field 'user[last_name]', with: @editing_user[:last_name]
-    assert_field 'user[email]', with: @editing_user[:email]
-    assert_field 'user[summary]', with: @editing_user[:summary]
-    assert_field 'user[zipcode]', with: @editing_user[:zipcode]
-    assert_field 'user[city]', with: @editing_user[:city]
-    assert_field 'user[country_code]', with: @editing_user[:country_code]
-  end
+    test 'should not change the password if old password is wrong' do
+      visit edit_user_registration_path
 
-  test 'should not save without password input' do
-    visit edit_user_registration_path
+      fill_in 'user[password]', with: 'new_password'
+      fill_in 'user[password_confirmation]', with: 'new_password'
+      fill_in 'user[old_password]', with: 'wrong_password'
 
-    fill_in 'user[first_name]', with: 'New name'
-    click_on 'Update'
+      click_on 'Confirm change'
 
-    assert_selector '.password-error', text: 'can\'t be blank'
-  end
-
-  test 'should update and redirect to home page' do
-    visit edit_user_registration_path
-
-    fill_in 'user[first_name]', with: 'New name'
-    submit_form
-
-    assert_selector 'div.flash', text: 'Your account has been updated successfully.'
-    assert_current_path root_path
-  end
-
-  test 'should present errors in form' do
-    visit edit_user_registration_path
-
-    fill_in 'user[last_name]', with: ''
-    submit_form
-
-    assert_no_current_path root_path
-    assert_selector '.form_error', text: 'Last name required'
-  end
-
-  test 'should not change the password if clicks on wrong button' do
-    visit edit_user_registration_path
-
-    fill_in 'user[password]', with: 'new_password'
-    fill_in 'user[password_confirmation]', with: 'new_password'
-    submit_form
-
-    # The password should not be updated
-    assert @editing_user.reload.valid_password?(@editing_user.password)
-  end
-
-  test 'should change the password' do
-    visit edit_user_registration_path
-
-    fill_in 'user[password]', with: 'new_password'
-    fill_in 'user[password_confirmation]', with: 'new_password'
-    fill_in 'user[old_password]', with: @editing_user.password
-
-    click_on 'Submit'
-
-    assert_selector 'div.flash', text: 'Your account has been updated successfully.'
-    assert_current_path root_path
-    assert @editing_user.reload.valid_password?('new_password')
-  end
-
-  private
-
-  def submit_form
-    fill_in 'user[current_password]', with: @editing_user.password
-    click_on 'Update'
+      assert_selector '.password-error', text: 'is invalid'
+      assert @editing_user.reload.valid_password?(@editing_user.password)
+    end
   end
 end

--- a/test/system/users/registration_workflow_test.rb
+++ b/test/system/users/registration_workflow_test.rb
@@ -2,138 +2,140 @@
 
 require 'system_test_helper'
 
-class RegistrationWorkflowTest < ApplicationSystemTestCase
-  def setup
-    random_address = ADDRESSES.first
+module Users
+  class RegistrationWorkflowTest < ApplicationSystemTestCase
+    def setup
+      random_address = ADDRESSES.first
 
-    @fake_user_data = FactoryBot.build(:user, :for_test)
-    @fake_user_data[:address] = AddressHelper::Formatter.format_address(random_address)
-    @fake_user_data[:zipcode] = random_address[:zipcode]
-    @fake_user_data[:city] = random_address[:city]
-    @fake_user_data[:country_code] = random_address[:country_code]
+      @fake_user_data = FactoryBot.build(:user, :for_test)
+      @fake_user_data[:address] = AddressHelper::Formatter.format_address(random_address)
+      @fake_user_data[:zipcode] = random_address[:zipcode]
+      @fake_user_data[:city] = random_address[:city]
+      @fake_user_data[:country_code] = random_address[:country_code]
 
-    @avatar = URI.parse(Faker::Avatar.image).open
+      @avatar = URI.parse(Faker::Avatar.image).open
 
-    @inviting_user = FactoryBot.create(:user, :for_test, :with_couch)
-  end
-
-  test 'should open validate invite code page' do
-    visit root_path
-
-    click_on 'Sign up'
-
-    assert_selector 'h1', text: 'Validate invite code'.upcase
-  end
-
-  test 'should throw error if code does not exist' do
-    visit '/invite-code'
-
-    assert_selector 'h1', text: 'Validate invite code'.upcase
-
-    # Fill in the form
-    fill_in 'invite[invite_code]', with: 'abcdef'
-    click_on 'Validate'
-
-    assert_selector 'div.flash', text: 'Invite code not found'
-  end
-
-  test 'should throw error if code is invalid' do
-    visit '/invite-code'
-
-    assert_selector 'h1', text: 'Validate invite code'.upcase
-
-    # Fill in the form
-    fill_in 'invite[invite_code]', with: 'invalid'
-    click_on 'Validate'
-
-    assert_selector 'div.flash', text: 'This does not look like a valid code'
-  end
-
-  test 'should redirect to sign up page if code is valid' do
-    visit '/invite-code'
-
-    assert_selector 'h1', text: 'Validate invite code'.upcase
-
-    # Fill in the form
-    fill_in 'invite[invite_code]', with: @inviting_user.invite_code
-    click_on 'Validate'
-
-    assert_selector 'h1', text: 'Set account details'.upcase
-  end
-
-  test 'should navigate to sign up page with code in url' do
-    visit user_registration_path
-
-    assert_selector 'h1', text: 'Set account details'.upcase
-  end
-
-  test 'should present errors in form' do
-    visit user_registration_path
-
-    fill_in 'user[first_name]', with: @fake_user_data[:first_name]
-    click_on 'Create Account'
-
-    assert_no_current_path root_path
-    assert_selector '.form_error', text: 'Last name required'
-  end
-
-  test 'should create a user with an invite code' do
-    visit user_registration_path
-
-    assert_selector 'h1', text: 'Set account details'.upcase
-
-    # Fill in the form
-    fill_in_form_data
-
-    click_on 'Create Account'
-
-    # Should be in the main page again and see success a message
-    assert_selector 'div.flash', text: 'A message with a confirmation link'
-    assert_current_path root_path
-
-    # Check that the user was created and has invited_by_id value set
-    user = User.last
-    assert_equal user[:email], @fake_user_data[:email]
-    assert_equal user[:invited_by_id], @inviting_user[:id]
-  end
-
-  private
-
-  def user_registration_path
-    "/users/sign_up?invite_code=#{@inviting_user[:invite_code]}"
-  end
-
-  def fill_in_form_data
-    attach_file(@avatar.path) do
-      find('div.input.file.user_photo').click
+      @inviting_user = FactoryBot.create(:user, :for_test, :with_couch)
     end
-    fill_in 'user[first_name]', with: @fake_user_data[:first_name]
-    fill_in 'user[last_name]', with: @fake_user_data[:last_name]
-    fill_in 'user[email]', with: @fake_user_data[:email]
-    month = @fake_user_data[:date_of_birth].strftime('%B')
-    year = @fake_user_data[:date_of_birth].year
-    day = @fake_user_data[:date_of_birth].day
-    select year, from: 'user_date_of_birth_1i'
-    select month, from: 'user_date_of_birth_2i'
-    select day, from: 'user_date_of_birth_3i'
-    fill_in 'user[summary]', with: @fake_user_data[:summary]
 
-    # Fill in the address
-    formatted_address = AddressHelper::Formatter.format_address(ADDRESSES.first)
-    fill_in 'Search', with: formatted_address
-    first_suggestion = first('.mapboxgl-ctrl-geocoder--suggestion')
-    first_suggestion.click
-    # make sure that all address fields are filled
-    fill_in 'user[zipcode]', with: @fake_user_data[:zipcode]
-    fill_in 'user[city]', with: @fake_user_data[:city]
+    test 'should open validate invite code page' do
+      visit root_path
 
-    # select characteristics
-    char_id = Characteristic.first.id
-    find("#user_characteristic_characteristic_ids_#{char_id}").check
-    check 'user[offers_hang_out]'
+      click_on 'Sign up'
 
-    password = Faker::Internet.password
-    fill_in 'user[password]', with: password
-    fill_in 'user[password_confirmation]', with: password
+      assert_selector 'h1', text: 'Validate invite code'.upcase
+    end
+
+    test 'should throw error if code does not exist' do
+      visit '/invite-code'
+
+      assert_selector 'h1', text: 'Validate invite code'.upcase
+
+      # Fill in the form
+      fill_in 'invite[invite_code]', with: 'abcdef'
+      click_on 'Validate'
+
+      assert_selector 'div.flash', text: 'Invite code not found'
+    end
+
+    test 'should throw error if code is invalid' do
+      visit '/invite-code'
+
+      assert_selector 'h1', text: 'Validate invite code'.upcase
+
+      # Fill in the form
+      fill_in 'invite[invite_code]', with: 'invalid'
+      click_on 'Validate'
+
+      assert_selector 'div.flash', text: 'This does not look like a valid code'
+    end
+
+    test 'should redirect to sign up page if code is valid' do
+      visit '/invite-code'
+
+      assert_selector 'h1', text: 'Validate invite code'.upcase
+
+      # Fill in the form
+      fill_in 'invite[invite_code]', with: @inviting_user.invite_code
+      click_on 'Validate'
+
+      assert_selector 'h1', text: 'Set account details'.upcase
+    end
+
+    test 'should navigate to sign up page with code in url' do
+      visit user_registration_path
+
+      assert_selector 'h1', text: 'Set account details'.upcase
+    end
+
+    test 'should present errors in form' do
+      visit user_registration_path
+
+      fill_in 'user[first_name]', with: @fake_user_data[:first_name]
+      click_on 'Create Account'
+
+      assert_no_current_path root_path
+      assert_selector '.form_error', text: 'Last name required'
+    end
+
+    test 'should create a user with an invite code' do
+      visit user_registration_path
+
+      assert_selector 'h1', text: 'Set account details'.upcase
+
+      # Fill in the form
+      fill_in_form_data
+
+      click_on 'Create Account'
+
+      # Should be in the main page again and see success a message
+      assert_selector 'div.flash', text: 'A message with a confirmation link'
+      assert_current_path root_path
+
+      # Check that the user was created and has invited_by_id value set
+      user = User.last
+      assert_equal user[:email], @fake_user_data[:email]
+      assert_equal user[:invited_by_id], @inviting_user[:id]
+    end
+
+    private
+
+    def user_registration_path
+      "/users/sign_up?invite_code=#{@inviting_user[:invite_code]}"
+    end
+
+    def fill_in_form_data
+      attach_file(@avatar.path) do
+        find('div.input.file.user_photo').click
+      end
+      fill_in 'user[first_name]', with: @fake_user_data[:first_name]
+      fill_in 'user[last_name]', with: @fake_user_data[:last_name]
+      fill_in 'user[email]', with: @fake_user_data[:email]
+      month = @fake_user_data[:date_of_birth].strftime('%B')
+      year = @fake_user_data[:date_of_birth].year
+      day = @fake_user_data[:date_of_birth].day
+      select year, from: 'user_date_of_birth_1i'
+      select month, from: 'user_date_of_birth_2i'
+      select day, from: 'user_date_of_birth_3i'
+      fill_in 'user[summary]', with: @fake_user_data[:summary]
+
+      # Fill in the address
+      formatted_address = AddressHelper::Formatter.format_address(ADDRESSES.first)
+      fill_in 'Search', with: formatted_address
+      first_suggestion = first('.mapboxgl-ctrl-geocoder--suggestion')
+      first_suggestion.click
+      # make sure that all address fields are filled
+      fill_in 'user[zipcode]', with: @fake_user_data[:zipcode]
+      fill_in 'user[city]', with: @fake_user_data[:city]
+
+      # select characteristics
+      char_id = Characteristic.first.id
+      find("#user_characteristic_characteristic_ids_#{char_id}").check
+      check 'user[offers_hang_out]'
+
+      password = Faker::Internet.password
+      fill_in 'user[password]', with: password
+      fill_in 'user[password_confirmation]', with: password
+    end
   end
 end

--- a/test/system/users/registration_workflow_test.rb
+++ b/test/system/users/registration_workflow_test.rb
@@ -7,10 +7,10 @@ class RegistrationWorkflowTest < ApplicationSystemTestCase
     random_address = ADDRESSES.first
 
     @fake_user_data = FactoryBot.build(:user, :for_test)
-    @fake_user_data[:address] = AddressHelper.format_address(random_address)
+    @fake_user_data[:address] = AddressHelper::Formatter.format_address(random_address)
     @fake_user_data[:zipcode] = random_address[:zipcode]
     @fake_user_data[:city] = random_address[:city]
-    @fake_user_data[:country] = random_address[:country_code]
+    @fake_user_data[:country_code] = random_address[:country_code]
 
     @avatar = URI.parse(Faker::Avatar.image).open
 
@@ -119,7 +119,7 @@ class RegistrationWorkflowTest < ApplicationSystemTestCase
     fill_in 'user[summary]', with: @fake_user_data[:summary]
 
     # Fill in the address
-    formatted_address = AddressHelper.format_address(ADDRESSES.first)
+    formatted_address = AddressHelper::Formatter.format_address(ADDRESSES.first)
     fill_in 'Search', with: formatted_address
     first_suggestion = first('.mapboxgl-ctrl-geocoder--suggestion')
     first_suggestion.click

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -69,13 +69,13 @@ module ActiveSupport
     # To add it to a test class, include ParallelizeTests
 
     # Setup all fixtures in test/fixtures/*.yml for all tests in alphabetical order.
-    fixtures :characteristics
+    fixtures :characteristics, :facilities
 
     # Add more helper methods to be used by all tests here...
 
     # default setup for all unit tests
     def params
-      @params ||= {}
+      @params ||= ActionController::Parameters.new
     end
 
     def session


### PR DESCRIPTION
Issue number: #68 

---------

### Description
Refactor the User class to have proper validation on update.

This fixes the issue where the country was being saved as a code upon user update, resulting in many entrances with wrong countries.

Changes include:
- the country "beautification" happens upon validation. This should prevent any users being saved with the wrong country.
- added "country_code" to the user, so we can have a backup in case something were to happen. Moreover, this prevents country codes from being accidentally saved to country.
- added a new validation context `:password_update` to handle password changes without needing the user to have all required fields.
- change profile page to have a clear separation of password update vs profile update

<img width="1121" alt="Screenshot 2024-09-04 at 12 04 24" src="https://github.com/user-attachments/assets/4bad752e-3d0d-4270-933a-e89c60ddab3e">

### Checklist
- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Rubocop passes
