### PR TITLE
add condition for booking date to not be older than one month to pend…

### DIFF
--- a/app/models/booking.rb
+++ b/app/models/booking.rb
@@ -40,11 +40,23 @@ class Booking < ApplicationRecord
   end
 
   def self.remind
-    pending_future_bookings = Booking.where(status: 0).where('start_date >= ?',
-                                                             Date.today).or(Booking.where(status: 0).where(
-                                                                              start_date: nil, flexible: true
-                                                                            ))
+    one_month_ago = Date.today - 1.month
+
+    pending_future_not_flexible_bookings = Booking.where(status: 0)
+                                                  .where('start_date >= ?', Date.today)
+
+    pending_future_flexible_bookings = Booking.where(status: 0)
+                                              .where(start_date: nil, flexible: true)
+                                              .where(
+                                                'booking_date >= ?', one_month_ago
+                                              )
+
+    pending_future_bookings = pending_future_not_flexible_bookings.or(pending_future_flexible_bookings)
+
     pending_past_bookings = Booking.where(status: 0).where('start_date < ?', Date.today)
+                                   .or(Booking.where(status: 0).where(start_date: nil, flexible: true)
+                                   .where('booking_date < ?', one_month_ago))
+
     pending_past_bookings.update_all(status: -2)
     return if pending_future_bookings.empty?
 

--- a/app/models/booking.rb
+++ b/app/models/booking.rb
@@ -42,8 +42,9 @@ class Booking < ApplicationRecord
   def self.remind
     one_month_ago = Date.today - 1.month
 
-    pending_future_not_flexible_bookings = Booking.where(status: 0)
-                                                  .where('start_date >= ?', Date.today)
+    pending_future_fixed_bookings = Booking.where(status: 0)
+                                           .where('start_date >= ?', Date.today)
+                                           .where(flexible: false)
 
     pending_future_flexible_bookings = Booking.where(status: 0)
                                               .where(start_date: nil, flexible: true)
@@ -51,7 +52,7 @@ class Booking < ApplicationRecord
                                                 'booking_date >= ?', one_month_ago
                                               )
 
-    pending_future_bookings = pending_future_not_flexible_bookings.or(pending_future_flexible_bookings)
+    pending_future_bookings = pending_future_fixed_bookings.or(pending_future_flexible_bookings)
 
     pending_past_bookings = Booking.where(status: 0).where('start_date < ?', Date.today)
                                    .or(Booking.where(status: 0).where(start_date: nil, flexible: true)

--- a/test/factories/bookings.rb
+++ b/test/factories/bookings.rb
@@ -14,23 +14,35 @@ FactoryBot.define do
       booking.couch = couch_owner.couch
     end
 
-    trait :past_pending do
-      start_date { Date.today - 2 }
-      end_date { Date.today - 1 }
-      status { 0 }
-    end
-
-    trait :future_pending do
+    trait :pending_future_not_flexible do
       start_date { Date.today }
       end_date { Date.today + 1 }
+      flexible { false }
       status { 0 }
+      booking_date { Date.yesterday }
     end
 
-    trait :future_pending_flexible do
+    trait :pending_future_flexible do
       start_date { nil }
       end_date { nil }
       flexible { true }
       status { 0 }
+      booking_date { Date.yesterday }
+    end
+
+    trait :pending_past_flexible do
+      start_date { nil }
+      end_date { nil }
+      flexible { true }
+      status { 0 }
+      booking_date { Date.today - 2.months }
+    end
+
+    trait :pending_past_not_flexible do
+      start_date { Date.today - 2.months }
+      end_date { Date.today - 1.months }
+      status { 0 }
+      booking_date { Date.yesterday - 2.months }
     end
 
     trait :confirmed do

--- a/test/factories/bookings.rb
+++ b/test/factories/bookings.rb
@@ -14,7 +14,7 @@ FactoryBot.define do
       booking.couch = couch_owner.couch
     end
 
-    trait :pending_future_not_flexible do
+    trait :pending_future_fixed do
       start_date { Date.today }
       end_date { Date.today + 1 }
       flexible { false }
@@ -38,7 +38,7 @@ FactoryBot.define do
       booking_date { Date.today - 2.months }
     end
 
-    trait :pending_past_not_flexible do
+    trait :pending_past_fixed do
       start_date { Date.today - 2.months }
       end_date { Date.today - 1.months }
       status { 0 }

--- a/test/models/booking_test.rb
+++ b/test/models/booking_test.rb
@@ -13,23 +13,23 @@ class BookingTest < ActiveSupport::TestCase
   end
 
   test 'should update status of past pending bookings to expired and send reminder emails for future bookings' do
-    pending_past_not_flexible_booking = FactoryBot.create(:booking, :pending_past_not_flexible)
-    pending_future_not_flexible_booking = FactoryBot.create(:booking, :pending_future_not_flexible)
+    pending_past_fixed_booking = FactoryBot.create(:booking, :pending_past_fixed)
+    pending_future_fixed_booking = FactoryBot.create(:booking, :pending_future_fixed)
     pending_future_flexible_booking = FactoryBot.create(:booking, :pending_future_flexible)
     pending_past_flexible_booking = FactoryBot.create(:booking, :pending_past_flexible)
 
     assert_emails 2 do
       Booking.remind
 
-      assert_equal 'expired', pending_past_not_flexible_booking.reload.status
+      assert_equal 'expired', pending_past_fixed_booking.reload.status
       assert_equal 'expired', pending_past_flexible_booking.reload.status
-      assert_equal 'pending', pending_future_not_flexible_booking.reload.status
+      assert_equal 'pending', pending_future_fixed_booking.reload.status
       assert_equal 'pending', pending_future_flexible_booking.reload.status
     end
   end
 
   test 'update_status should update status of given bookings' do
-    FactoryBot.create_list(:booking, 2, :pending_future_not_flexible)
+    FactoryBot.create_list(:booking, 2, :pending_future_fixed)
     bookings_relation = Booking.where(status: 'pending')
     Booking.update_status(bookings_relation, 'confirmed')
 
@@ -46,7 +46,7 @@ class BookingTest < ActiveSupport::TestCase
   end
 
   test 'send_reminder_emails should send reminder emails to hosts' do
-    booking = FactoryBot.create(:booking, :pending_future_not_flexible)
+    booking = FactoryBot.create(:booking, :pending_future_fixed)
 
     assert_emails 1 do
       Booking.send_reminder_emails([booking])

--- a/test/models/booking_test.rb
+++ b/test/models/booking_test.rb
@@ -13,21 +13,23 @@ class BookingTest < ActiveSupport::TestCase
   end
 
   test 'should update status of past pending bookings to expired and send reminder emails for future bookings' do
-    past_pending_booking = FactoryBot.create(:booking, :past_pending)
-    future_pending_booking = FactoryBot.create(:booking, :future_pending)
-    future_pending_flexible_booking = FactoryBot.create(:booking, :future_pending_flexible)
+    pending_past_not_flexible_booking = FactoryBot.create(:booking, :pending_past_not_flexible)
+    pending_future_not_flexible_booking = FactoryBot.create(:booking, :pending_future_not_flexible)
+    pending_future_flexible_booking = FactoryBot.create(:booking, :pending_future_flexible)
+    pending_past_flexible_booking = FactoryBot.create(:booking, :pending_past_flexible)
 
     assert_emails 2 do
       Booking.remind
 
-      assert_equal 'expired', past_pending_booking.reload.status
-      assert_equal 'pending', future_pending_booking.reload.status
-      assert_equal 'pending', future_pending_flexible_booking.reload.status
+      assert_equal 'expired', pending_past_not_flexible_booking.reload.status
+      assert_equal 'expired', pending_past_flexible_booking.reload.status
+      assert_equal 'pending', pending_future_not_flexible_booking.reload.status
+      assert_equal 'pending', pending_future_flexible_booking.reload.status
     end
   end
 
   test 'update_status should update status of given bookings' do
-    FactoryBot.create_list(:booking, 2, :pending)
+    FactoryBot.create_list(:booking, 2, :pending_future_not_flexible)
     bookings_relation = Booking.where(status: 'pending')
     Booking.update_status(bookings_relation, 'confirmed')
 
@@ -44,7 +46,7 @@ class BookingTest < ActiveSupport::TestCase
   end
 
   test 'send_reminder_emails should send reminder emails to hosts' do
-    booking = FactoryBot.create(:booking, :future_pending)
+    booking = FactoryBot.create(:booking, :pending_future_not_flexible)
 
     assert_emails 1 do
       Booking.send_reminder_emails([booking])


### PR DESCRIPTION
I added a condition that flexible bookings that are still pending are only considered as future pending bookings if the booking date is not older than a month, otherwise we will set it to expired. 

This will probably fix the SMTP issue anywas, let's observe. 

### Checklist
- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Rubocop passes

