### PR TITLE
feat: add country code fixer

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,13 @@ For that, you need to run `rails test:system`.
 However, it's a good idea to run tests in the testing environment, so your development environment doesn't get polluted
 or deleted.
 
+Some tests are marked as slow and are not run by default. To run all tests, including slow tests, you can run the following
+command:
+
+```bash
+SLOW_TESTS=true rails test
+```
+
 #### 4.2.1 Running tests in `test` environment
 
 1. Create and setup the test database:

--- a/app/helpers/address_helper.rb
+++ b/app/helpers/address_helper.rb
@@ -4,13 +4,15 @@ module AddressHelper
   def beautify_country(country)
     Rails.logger.info("Beautifying country: #{country}")
     iso_country = ISO3166::Country[country]
+    raise StandardError, 'iso_country is empty' if iso_country.nil?
+
     translated_country = iso_country.translations[I18n.locale.to_s]
     Rails.logger.info("Country beautification: #{country} -> #{iso_country} -> #{translated_country}")
-    raise StandardError if translated_country.nil? || translated_country == country
+    raise StandardError, 'translated_country is empty' if translated_country.nil? || translated_country == country
 
     translated_country
   rescue StandardError => e
-    Rails.logger.error("Error updating user profile: #{e.message}")
+    Rails.logger.error("Error beautifying country: #{e.message}")
     crumb = Sentry::Breadcrumb.new(
       message: 'Error beautifying country',
       level: 'error',
@@ -24,7 +26,10 @@ module AddressHelper
   def find_country_code(country)
     Rails.logger.info("Finding country code: #{country}")
     iso_country = ISO3166::Country.find_country_by_iso_short_name(country)
-    Rails.logger.info("Country code found: #{iso_country.alpha2}")
+    if iso_country.nil?
+      return handle_non_iso_conform_country(country)
+    end
+    Rails.logger.info("Country code found: #{iso_country}")
     iso_country.alpha2
   rescue StandardError => e
     Rails.logger.error("Error finding country code: #{e.message}")
@@ -33,6 +38,42 @@ module AddressHelper
   class Formatter
     def self.format_address(address)
       "#{address[:street]}, #{address[:zipcode]}, #{address[:city]}, #{address[:country]}"
+    end
+  end
+
+  private
+
+  # Handle countries whose english translation is not the same as the iso short name
+  def handle_non_iso_conform_country(country)
+    case country.downcase
+    when 'united states'
+      return 'US'
+    when 'united kingdom'
+      return 'GB'
+    when 'bolivia'
+      return 'BO'
+    when 'congo, the democratic republic of the'
+      return 'CD'
+    when 'iran'
+      return 'IR'
+    when 'north korea'
+      return 'KP'
+    when 'south korea'
+      return 'KR'
+    when 'moldova'
+      return 'MD'
+    when 'taiwan'
+      return 'TW'
+    when 'tanzania'
+      return 'TZ'
+    when 'holy see (vatican city state)'
+      return 'VA'
+    when 'venezuela'
+      return 'VE'
+    when 'vietnam'
+      return 'VN'
+    else
+      raise ArgumentError, "Country not found: #{country}"
     end
   end
 end

--- a/app/helpers/address_helper.rb
+++ b/app/helpers/address_helper.rb
@@ -21,6 +21,15 @@ module AddressHelper
     raise ArgumentError, "Country not found: #{country}"
   end
 
+  def find_country_code(country)
+    Rails.logger.info("Finding country code: #{country}")
+    iso_country = ISO3166::Country.find_country_by_iso_short_name(country)
+    Rails.logger.info("Country code found: #{iso_country.alpha2}")
+    iso_country.alpha2
+  rescue StandardError => e
+    Rails.logger.error("Error finding country code: #{e.message}")
+  end
+
   class Formatter
     def self.format_address(address)
       "#{address[:street]}, #{address[:zipcode]}, #{address[:city]}, #{address[:country]}"

--- a/lib/tasks/convert_country_to_country_code.rake
+++ b/lib/tasks/convert_country_to_country_code.rake
@@ -1,0 +1,18 @@
+require_relative '../../app/helpers/address_helper'
+include AddressHelper
+
+namespace :users do
+  desc 'Convert country to country code'
+  task convert_country_to_country_code: :environment do
+    User.all.each do |user|
+      current_country_code = user.country_code
+      update_with_country = nil
+      update_with_country = user.country if current_country_code == user.country || current_country_code.blank?
+
+      if update_with_country
+        user.update_attribute(:country_code, find_country_code(update_with_country))
+        user.validate_country_code
+      end
+    end
+  end
+end

--- a/test/helpers/address_helper_test.rb
+++ b/test/helpers/address_helper_test.rb
@@ -47,4 +47,29 @@ class AddressHelperTest < ActiveSupport::TestCase
     country = 'Bhutan'
     assert_equal 'BT', find_country_code(country)
   end
+
+  test 'should map United States to US' do
+    country = 'United States'
+    assert_equal 'US', find_country_code(country)
+  end
+
+  test 'should map United Kingdom to GB' do
+    country = 'United Kingdom'
+    assert_equal 'GB', find_country_code(country)
+  end
+
+  test 'should handle all countries where the iso_short_name does not match the translation' do
+    skip 'This test is slow and should be run manually' unless ENV['SLOW_TESTS']
+
+    all_iso_countries = ISO3166::Country.all
+
+    all_iso_countries.each do |iso_country|
+      country = beautify_country(iso_country.alpha2)
+      if country != iso_country.iso_short_name
+        puts "Country '#{country}' has a translation that is not the same as the short name #{iso_country.iso_short_name}"
+
+        assert_equal iso_country.alpha2, find_country_code(country)
+      end
+    end
+  end
 end

--- a/test/helpers/address_helper_test.rb
+++ b/test/helpers/address_helper_test.rb
@@ -33,4 +33,18 @@ class AddressHelperTest < ActiveSupport::TestCase
     formatted_address = AddressHelper::Formatter.format_address(address)
     assert_equal 'Main Street, 12345, Springfield, US', formatted_address
   end
+
+  test 'should find country code' do
+    country = 'Germany'
+    assert_equal 'DE', find_country_code(country)
+
+    country = 'Netherlands'
+    assert_equal 'NL', find_country_code(country)
+
+    country = 'Oman'
+    assert_equal 'OM', find_country_code(country)
+
+    country = 'Bhutan'
+    assert_equal 'BT', find_country_code(country)
+  end
 end

--- a/test/tasks/correct_country_code_test.rb
+++ b/test/tasks/correct_country_code_test.rb
@@ -9,25 +9,13 @@ class CorrectCountryCodeTest < ActiveSupport::TestCase
     Rails.application.load_tasks
   end
 
-  test 'should change Germany to DE' do
-    # prepare the data to have one user with country Germany
-    @user = User.all.sample
-    @user.update_attribute(:country_code, 'Germany')
-    @user.update_attribute(:country, 'Germany')
-
-    Rake::Task['users:convert_country_to_country_code'].invoke
-
-    # assert that the country codes have been converted
-    @user.reload
-    assert_equal 'DE', @user.country_code
-    assert_equal 'Germany', @user.country
-  end
-
   test 'should convert country to country code' do
     original_countries = {}
     # prepare the data to have users with invalid country codes
     User.all.each do |user|
-      user.update_attribute(:country_code, user.country)
+      random_country = ADDRESSES.sample[:country]
+      user.update_attribute(:country_code, random_country)
+      user.update_attribute(:country, random_country)
       original_countries[user.id] = user.country
     end
 

--- a/test/tasks/correct_country_code_test.rb
+++ b/test/tasks/correct_country_code_test.rb
@@ -1,0 +1,42 @@
+require 'test_helper'
+require 'rake'
+
+class CorrectCountryCodeTest < ActiveSupport::TestCase
+  fixtures :users
+
+  setup do
+    # load the rake tasks
+    Rails.application.load_tasks
+  end
+
+  test 'should change Germany to DE' do
+    # prepare the data to have one user with country Germany
+    @user = User.all.sample
+    @user.update_attribute(:country_code, 'Germany')
+    @user.update_attribute(:country, 'Germany')
+
+    Rake::Task['users:convert_country_to_country_code'].invoke
+
+    # assert that the country codes have been converted
+    @user.reload
+    assert_equal 'DE', @user.country_code
+    assert_equal 'Germany', @user.country
+  end
+
+  test 'should convert country to country code' do
+    original_countries = {}
+    # prepare the data to have users with invalid country codes
+    User.all.each do |user|
+      user.update_attribute(:country_code, user.country)
+      original_countries[user.id] = user.country
+    end
+
+    Rake::Task['users:convert_country_to_country_code'].invoke
+
+    # assert that the country codes have been converted
+    User.all.each do |user|
+      assert_not_equal user.country, user.country_code
+      assert_equal original_countries[user.id], user.country
+    end
+  end
+end


### PR DESCRIPTION
### Description
Not all country codes have been properly set in the production DB, this script should fix that!

Context: 
We had a bunch of countries in the DB that were not correct, such as “DE” or “US”.
When we ran the migration from #132, all of the country names were copied to the country_code. This works for all the countries that were looking like “DE”, but the ones that were correct need to be fixed back to a valid country code. So if right now `country_code` is “Germany”, it needs to be converted to “DE”. This script should handle that.

What the script does is it checks if the `country == country_code` or if the `country_code` is empty, and then tries to find a country code from the country name, e.g from “Germany” try to get “DE”.
I do this by using the `ISO3166::Country` class which we were already using. This presents some issues for countries whose english translations are not the same as the `iso_short_name`.
For example, it does not work for the US, where the `iso_short_name` is “United States of America” and the translation to english is “United States”, so I have to do a bit more to get those handled. 

This is NOT a problem for the app in general, only for the automatic finding of the right country code.

### Checklist
- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Rubocop passes
