### PR TITLE
Feat/improve amplitude events

### DIFF
--- a/app/controllers/bookings_controller.rb
+++ b/app/controllers/bookings_controller.rb
@@ -54,7 +54,7 @@ class BookingsController < ApplicationController
     if @booking.save
       @booking.pending!
       BookingMailer.with(booking: @booking).new_request_email.deliver_later
-      track_booking_event_amplitude('New Booking')
+      AmplitudeEventTracker.track_booking_event(@booking, 'New Booking')
       create_chat_and_message(@booking)
       redirect_to sent_booking_path(@booking)
     else
@@ -79,7 +79,7 @@ class BookingsController < ApplicationController
       BookingMailer.with(booking: @booking).booking_updated_email.deliver_later
     end
     redirect_to booking_path(@booking)
-    track_booking_event_amplitude('Booking Updated')
+    AmplitudeEventTracker.track_booking_event(@booking, 'Booking Updated')
   end
 
   def cancel
@@ -101,7 +101,7 @@ class BookingsController < ApplicationController
       redirect_to requests_couch_bookings_path(@booking.couch)
       BookingMailer.with(booking: @booking).booking_cancelled_by_host_email.deliver_later
     end
-    track_booking_event_amplitude('Booking Cancelled')
+    AmplitudeEventTracker.track_booking_event(@booking, 'Booking Cancelled')
   end
 
   def show_request
@@ -130,7 +130,7 @@ class BookingsController < ApplicationController
     return unless @booking.confirmed!
 
     BookingMailer.with(booking: @booking).request_confirmed_email.deliver_later
-    track_booking_event_amplitude('Booking Confirmed')
+    AmplitudeEventTracker.track_booking_event(@booking, 'Booking Confirmed')
   end
 
   def decline(chat)
@@ -155,7 +155,7 @@ class BookingsController < ApplicationController
       Message.create(user_id: current_user.id, chat:, content:)
       decline(chat)
     end
-    track_booking_event_amplitude('Booking Declined')
+    AmplitudeEventTracker.track_booking_event(@booking, 'Booking Declined')
   end
 
   private
@@ -205,23 +205,6 @@ class BookingsController < ApplicationController
       redirect_to requests_couch_bookings_path(booking.couch)
       BookingMailer.with(booking:).booking_cancelled_by_host_email.deliver_later
     end
-  end
-
-  def track_booking_event_amplitude(amplitude_event)
-    event = AmplitudeAPI::Event.new(
-      user_id: current_user.id.to_s,
-      event_type: amplitude_event,
-      couch: @booking.couch_id,
-      booking: @booking.id,
-      flexible: @booking.flexible,
-      request: @booking.request,
-      status: @booking.status,
-      start_date: @booking.start_date,
-      end_date: @booking.end_date,
-      number_travellers: @booking.number_travellers,
-      time: Time.now
-    )
-    AmplitudeAPI.track(event)
   end
 
   def find_chat(user1, user2)

--- a/app/controllers/bookings_controller.rb
+++ b/app/controllers/bookings_controller.rb
@@ -89,18 +89,7 @@ class BookingsController < ApplicationController
     @canceller = current_user
     return unless @booking.save
 
-    if @canceller == @booking.user
-      redirect_to bookings_path
-      case status_before_cancellation
-      when 'pending'
-        BookingMailer.with(booking: @booking).request_cancelled_email.deliver_later
-      when 'confirmed'
-        BookingMailer.with(booking: @booking).booking_cancelled_by_guest_email.deliver_later
-      end
-    else
-      redirect_to requests_couch_bookings_path(@booking.couch)
-      BookingMailer.with(booking: @booking).booking_cancelled_by_host_email.deliver_later
-    end
+    cancel_booking(@canceller, @booking, status_before_cancellation)
     AmplitudeEventTracker.track_booking_event(@booking, 'Booking Cancelled')
   end
 

--- a/app/controllers/contacts_controller.rb
+++ b/app/controllers/contacts_controller.rb
@@ -19,6 +19,7 @@ class ContactsController < ApplicationController
 
     if @contact.deliver
       flash[:notice] = 'Message successfully sent!'
+      AmplitudeEventTracker.track_contact_event(params, 'Request for Invite Code') if params[:contact][:type] == 'code'
       redirect_to root_path
     else
       flash[:alert] = 'Could not send message, please try again'

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -14,13 +14,7 @@ class MessagesController < ApplicationController
     )
     head :ok
 
-    event = AmplitudeAPI::Event.new(
-      user_id: current_user.id.to_s,
-      event_type: 'New Message',
-      time: Time.now
-    )
-
-    AmplitudeAPI.track(event)
+    AmplitudeEventTracker.track_message_event('New Message')
   end
 
   private

--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -15,16 +15,7 @@ class ReviewsController < ApplicationController
     @review.booking = @booking
     handle_review(@booking, @review)
 
-    event = AmplitudeAPI::Event.new(
-      user_id: current_user.id.to_s,
-      event_type: 'New Review',
-      rating: @review.rating,
-      couch: @review.couch.id,
-      booking: @review.booking.id,
-      time: Time.now
-    )
-
-    AmplitudeAPI.track(event)
+    AmplitudeEventTracker.track_review_event(@review, 'New Review')
   end
 
   private

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -41,20 +41,7 @@ module Users
         respond_with resource
       end
 
-      event = AmplitudeAPI::Event.new(
-        user_id: resource.id.to_s,
-        event_type: 'New User',
-        user_properties: {
-          age: resource.calculated_age,
-          country: resource.country,
-          host: resource.offers_couch,
-          travelling: resource.travelling,
-          invited_by: resource.invited_by_id
-        },
-        time: Time.now
-      )
-
-      AmplitudeAPI.track(event)
+      AmplitudeEventTracker.track_user_event(resource, 'New User')
     end
 
     def update

--- a/app/models/booking.rb
+++ b/app/models/booking.rb
@@ -66,6 +66,9 @@ class Booking < ApplicationRecord
 
   def self.update_status(bookings, status)
     bookings.update_all(status:)
+    bookings.each do |booking|
+      AmplitudeEventTracker.track_booking_event(booking, 'Booking Completed')
+    end
   end
 
   def self.send_completed_emails(bookings)

--- a/app/services/amplitude_event_tracker.rb
+++ b/app/services/amplitude_event_tracker.rb
@@ -1,0 +1,66 @@
+class AmplitudeEventTracker
+  def self.track_booking_event(booking, event_type)
+    event = AmplitudeAPI::Event.new(
+      user_id: booking.user.id.to_s,
+      event_type:,
+      couch: booking.couch_id,
+      booking: booking.id,
+      flexible: booking.flexible,
+      request: booking.request,
+      status: booking.status,
+      start_date: booking.start_date,
+      end_date: booking.end_date,
+      number_travellers: booking.number_travellers,
+      time: Time.now
+    )
+    AmplitudeAPI.track(event)
+  end
+
+  def self.track_contact_event(params, event_type)
+    event = AmplitudeAPI::Event.new(
+      user_id: 'not_logged_in',
+      event_type:,
+      source: params[:contact][:source],
+      message: params[:contact][:message],
+      time: Time.now
+    )
+    AmplitudeAPI.track(event)
+  end
+
+  def self.track_message_event(event_type)
+    event = AmplitudeAPI::Event.new(
+      user_id: current_user.id.to_s,
+      event_type:,
+      time: Time.now
+    )
+    AmplitudeAPI.track(event)
+  end
+
+  def self.track_review_event(review, event_type)
+    event = AmplitudeAPI::Event.new(
+      user_id: current_user.id.to_s,
+      event_type:,
+      rating: review.rating,
+      couch: review.couch.id,
+      booking: review.booking.id,
+      time: Time.now
+    )
+    AmplitudeAPI.track(event)
+  end
+
+  def self.track_user_event(user, event_type)
+    event = AmplitudeAPI::Event.new(
+      user_id: user.id.to_s,
+      event_type:,
+      user_properties: {
+        age: user.calculated_age,
+        country: user.country,
+        host: user.offers_couch,
+        travelling: user.travelling,
+        invited_by: user.invited_by_id
+      },
+      time: Time.now
+    )
+    AmplitudeAPI.track(event)
+  end
+end

--- a/test/integration/bookings_controller_test.rb
+++ b/test/integration/bookings_controller_test.rb
@@ -1,0 +1,94 @@
+require 'test_helper'
+
+class BookingsControllerTest < ActionDispatch::IntegrationTest
+  include Devise::Test::IntegrationHelpers
+
+  setup do
+    @user = FactoryBot.create(:user, :for_test, :with_couch)
+    @other_user = FactoryBot.create(:user)
+    @couch = @user.couch
+    @booking = FactoryBot.create(:booking, couch: @couch, user: @other_user)
+    sign_in @user
+  end
+
+  test 'should create booking and track amplitude event' do
+    AmplitudeEventTracker.stub(:track_booking_event, true) do
+      assert_difference('Booking.count', 1, 'Booking was not created') do
+        post couch_bookings_path(@couch), params: {
+          booking: {
+            user_id: @other_user.id,
+            couch_id: @couch.id,
+            request: 'host',
+            start_date: Date.today,
+            end_date: Date.today + 1,
+            number_travellers: 1,
+            message: 'Looking forward to staying!'
+          }
+        }
+      end
+    end
+
+    booking = Booking.last
+    chat = Chat.last
+    message = chat.messages.last
+
+    assert_equal @user, message.user
+    assert_equal 'Looking forward to staying!', message.content
+    assert_equal @couch, booking.couch
+    assert_equal @user, booking.user
+    assert_equal Date.today, booking.booking_date
+    assert_equal 'pending', booking.status
+
+    assert_enqueued_emails 1
+
+    assert_redirected_to sent_booking_path(booking)
+  end
+
+  test 'should update booking and track amplitude event' do
+    AmplitudeEventTracker.stub(:track_booking_event, true) do
+      patch booking_path(@booking), params: { booking: { message: 'Updated message' } }
+    end
+    assert_redirected_to booking_path(@booking)
+    assert_enqueued_emails 1
+    @booking.reload
+    assert_equal 'Updated message', @booking.message
+  end
+
+  test 'should cancel booking and track amplitude event' do
+    AmplitudeEventTracker.stub(:track_booking_event, true) do
+      delete cancel_booking_path(@booking)
+    end
+    assert_redirected_to requests_couch_bookings_path(@booking.couch)
+    @booking.reload
+    assert_equal 'cancelled', @booking.status
+  end
+
+  test 'should accept booking and track amplitude event' do
+    AmplitudeEventTracker.stub(:track_booking_event, true) do
+      patch accept_booking_path(@booking)
+    end
+    @booking.reload
+    assert_enqueued_emails 1
+    assert_equal 'confirmed', @booking.status
+  end
+
+  test 'should decline booking, send message, and track amplitude event' do
+    # Case 1: Message is provided
+    AmplitudeEventTracker.stub(:track_booking_event, true) do
+      patch decline_and_send_message_booking_path(@booking), params: { message: 'Sorry, cannot host' }
+    end
+    chat = Chat.last
+    assert_redirected_to chat_path(chat)
+    @booking.reload
+    assert_equal 'declined', @booking.status
+    assert_equal 'Sorry, cannot host', chat.messages.last.content
+
+    # Case 2: Message is blank
+    AmplitudeEventTracker.stub(:track_booking_event, true) do
+      patch decline_and_send_message_booking_path(@booking), params: { message: '' }
+    end
+    assert_redirected_to requests_couch_bookings_path(@booking.couch)
+    @booking.reload
+    assert_equal 'declined', @booking.status
+  end
+end


### PR DESCRIPTION
This PR adds tracking events on Amplitude for two events:

- visitor requests invite code
- booking gets completed through rake task

As I am now tracking events inside my Booking model and the bookings controller, I created a service for tracking Amplitude events so that the functionality is centralized.

I added tests for the bookings controller (tests for the other Amplitude API calls within the newly created service will follow).