### PR TITLE
fix: filter couches without fetching with JS

### DIFF
--- a/app/controllers/api/v1/bookings_controller.rb
+++ b/app/controllers/api/v1/bookings_controller.rb
@@ -71,7 +71,8 @@ module Api
       def create_params
         params.require(:data).require(%i[type attributes relationships])
 
-        jsonapi_deserialize(params, only: %i[request status start_date end_date number_travellers message flexible user couch])
+        jsonapi_deserialize(params,
+                            only: %i[request status start_date end_date number_travellers message flexible user couch])
       end
     end
   end

--- a/app/controllers/couches_controller.rb
+++ b/app/controllers/couches_controller.rb
@@ -5,6 +5,8 @@ require_relative 'concerns/couches_concern'
 # CouchesController: This controller is responsible for handling the couches.
 class CouchesController < ApplicationController
   include CouchesConcern
+  include ActiveStorage::SetCurrent unless Rails.env.production?
+
   respond_to :html
 
   def show

--- a/app/javascript/controllers/couch_search_controller.js
+++ b/app/javascript/controllers/couch_search_controller.js
@@ -17,11 +17,8 @@ export default class extends Controller {
 	}
 
 	search() {
-		clearTimeout(this.timeout)
-		this.timeout = setTimeout(() => {
-			this.setUrlWithParams()
-			this.formTarget.requestSubmit()
-		}, 10)
+		this.setUrlWithParams()
+		this.formTarget.requestSubmit()
 	}
 
 	filter() {

--- a/app/javascript/controllers/couch_search_controller.js
+++ b/app/javascript/controllers/couch_search_controller.js
@@ -3,21 +3,7 @@ import { Controller } from '@hotwired/stimulus'
 export default class extends Controller {
 	static targets = ['form']
 
-	setUrlWithParams() {
-		const formData = new FormData(this.formTarget)
-		// remove "city" from the form data, as we don't want to show it in the URL
-		formData.delete('city')
-
-		let urlSearchParams = new URLSearchParams(formData)
-
-		const searchParams = urlSearchParams.toString()
-		const url = `${this.formTarget.action}?${searchParams}`
-
-		window.history.pushState('', '', url)
-	}
-
 	search() {
-		this.setUrlWithParams()
 		this.formTarget.requestSubmit()
 	}
 
@@ -40,7 +26,6 @@ export default class extends Controller {
 				element.checked = false
 			}
 		}
-		window.history.pushState('', '', url)
 		this.search()
 	}
 }

--- a/app/javascript/controllers/display_filters_controller.js
+++ b/app/javascript/controllers/display_filters_controller.js
@@ -2,9 +2,15 @@ import { Controller } from '@hotwired/stimulus'
 
 // Connects to data-controller="display-filters"
 export default class extends Controller {
-	static targets = ['filters']
+	static targets = ['filters', 'input']
 
 	connect() {
+		// Check if the show_filters parameter is set to true
+		if (this.inputTarget.value === 'true') {
+			this.filtersTarget.classList.remove('display-none')
+			return
+		}
+
 		// Use window.innerWidth in favor of window.screen.width. Why?
 		// window.innerWidth is the width of the window's viewport,
 		// whereas window.screen.width returns the actual screen size
@@ -19,5 +25,8 @@ export default class extends Controller {
 	toggleFilters(event) {
 		this.filtersTarget.classList.toggle('display-none')
 		event.currentTarget.classList.toggle('search__hide-filters--active')
+
+		// Set the value for `show_filters` in the form
+		this.inputTarget.value = this.filtersTarget.classList.contains('display-none') ? 'false' : 'true'
 	}
 }

--- a/app/views/couches/_list.html.erb
+++ b/app/views/couches/_list.html.erb
@@ -1,4 +1,4 @@
-<div data-characteristics-filter-target="couches">
+<div>
   <ul class="couches__list">
     <% @couches.each do |couch| %>
       <% if couch.user.photo.key %>
@@ -9,7 +9,7 @@
             <% end %>
             <div class="couches__content">
               <ul class="couches__features features">
-                <% couch.user.characteristics.each  do |characteristic| %>
+                <% couch.user.characteristics.each do |characteristic| %>
                   <li><%= characteristic.name %></li>
                 <% end %>
               </ul>

--- a/app/views/couches/index.html.erb
+++ b/app/views/couches/index.html.erb
@@ -4,7 +4,7 @@
                   class: 'search',
                   data: {
                     controller: 'couch-search',
-                    couch_search_target: "form" },
+                    couch_search_target: 'form' },
                   method: :get do %>
       <div class="search__wrap">
         <div data-controller="autocomplete" data-autocomplete-url-value="/search_cities" role="combobox" class="search__autocomplete">
@@ -14,11 +14,11 @@
                              placeholder: 'Find hosts in location',
                              class: 'form-control',
                              data: { autocomplete_target: 'input' } %>
-          <%= hidden_field_tag 'city', data: { autocomplete_target: 'hidden' } %>
           <ul class="search__autocomplete-list" data-autocomplete-target="results"></ul>
         </div>
         <%= submit_tag 'Search', class: 'search__button', data: { action: 'click->couch-search#search' } %>
         <i data-action="click->display-filters#toggleFilters" class="fa fa-filter fa-lg search__hide-filters"></i>
+        <%= hidden_field_tag 'show_filters', params['show_filters'], data: { display_filters_target: 'input' } %>
         <button class="search__clear" data-action="click->couch-search#reset">Clear Filters</button>
       </div>
       <div class="display-none" data-display-filters-target="filters">
@@ -42,7 +42,7 @@
           <%= check_box_tag 'offers_hang_out',
                             '1',
                             params[:offers_hang_out] == 'true',
-                            checked: params[:offers_co_work] == '1',
+                            checked: params[:offers_hang_out] == '1',
                             id: 'offers_hang',
                             class: 'search__checkbox offer__checkbox',
                             data: { action: 'change->couch-search#filter' } %>

--- a/app/views/couches/index.html.erb
+++ b/app/views/couches/index.html.erb
@@ -1,67 +1,68 @@
-<div class="home__wrap" data-controller="characteristics-filter">
+<div class="home__wrap">
   <section class="search__section" data-controller="display-filters">
     <%= form_with url: couches_path,
-										class: 'search',
-										data: { characteristics_filter_target: 'form',
-														action: 'submit->characteristics-filter#listCouches' },
-										method: :get do %>
+                  class: 'search',
+                  data: {
+                    controller: 'couch-search',
+                    couch_search_target: "form" },
+                  method: :get do %>
       <div class="search__wrap">
         <div data-controller="autocomplete" data-autocomplete-url-value="/search_cities" role="combobox" class="search__autocomplete">
           <%= text_field_tag :query,
-																params[:query],
-																value: params[:query],
-																placeholder: 'Find hosts in location',
-																class: 'form-control',
-																data: { autocomplete_target: 'input' } %>
+                             params[:query],
+                             value: params[:query],
+                             placeholder: 'Find hosts in location',
+                             class: 'form-control',
+                             data: { autocomplete_target: 'input' } %>
           <%= hidden_field_tag 'city', data: { autocomplete_target: 'hidden' } %>
           <ul class="search__autocomplete-list" data-autocomplete-target="results"></ul>
         </div>
-        <%= submit_tag 'Search', class: 'search__button' %>
+        <%= submit_tag 'Search', class: 'search__button', data: { action: 'click->couch-search#search' } %>
         <i data-action="click->display-filters#toggleFilters" class="fa fa-filter fa-lg search__hide-filters"></i>
-        <button class="search__clear" data-action="click->characteristics-filter#resetForm">Clear Filters</button>
+        <button class="search__clear" data-action="click->couch-search#reset">Clear Filters</button>
       </div>
       <div class="display-none" data-display-filters-target="filters">
         <div class="search__offers">
           <%= check_box_tag 'offers_couch',
-								'1',
-								params[:offers_couch] == 'true',
-								checked: params[:offers_couch] == '1',
-								id: 'offers_couch',
-								class: 'search__checkbox offer__checkbox',
-								data: { action: 'change->characteristics-filter#listCouches' } %>
+                            '1',
+                            params[:offers_couch] == 'true',
+                            checked: params[:offers_couch] == '1',
+                            id: 'offers_couch',
+                            class: 'search__checkbox offer__checkbox',
+                            data: { action: 'change->couch-search#filter' } %>
           <%= label_tag 'offers_couch', 'host' %>
           <%= check_box_tag 'offers_co_work',
-								'1',
-								params[:offers_co_work] == 'true',
-								checked: params[:offers_co_work] == '1',
-								id: 'offers_co_work',
-								class: 'search__checkbox offer__checkbox',
-								data: { action: 'change->characteristics-filter#listCouches' } %>
+                            '1',
+                            params[:offers_co_work] == 'true',
+                            checked: params[:offers_co_work] == '1',
+                            id: 'offers_co_work',
+                            class: 'search__checkbox offer__checkbox',
+                            data: { action: 'change->couch-search#filter' } %>
           <%= label_tag 'offers_co_work', 'cowork' %>
           <%= check_box_tag 'offers_hang_out',
-								'1',
-								params[:offers_hang_out] == 'true',
-								checked: params[:offers_co_work] == '1',
-								id: 'offers_hang',
-								class: 'search__checkbox offer__checkbox',
-								data: { action: 'change->characteristics-filter#listCouches' } %>
+                            '1',
+                            params[:offers_hang_out] == 'true',
+                            checked: params[:offers_co_work] == '1',
+                            id: 'offers_hang',
+                            class: 'search__checkbox offer__checkbox',
+                            data: { action: 'change->couch-search#filter' } %>
           <%= label_tag 'offers_hang', 'hang out' %>
         </div>
         <div class="search__characteristics" data-display-filters-target="filters">
           <% Characteristic.all.each do |characteristic| %>
             <%= check_box_tag 'characteristics[]',
-									characteristic.id,
-									params[:characteristics]&.include?(characteristic.id.to_s),
-									id: "characteristic_#{characteristic.id}",
-									class: 'search__checkbox',
-									data: { action: 'change->characteristics-filter#listCouches' } %>
+                              characteristic.id,
+                              params[:characteristics]&.include?(characteristic.id.to_s),
+                              id: "characteristic_#{characteristic.id}",
+                              class: 'search__checkbox',
+                              data: { action: 'change->couch-search#filter' } %>
             <%= label_tag "characteristic_#{characteristic.id}", characteristic.name %>
           <% end %>
         </div>
       </div>
     <% end %>
   </section>
-  <section data-characteristics-filter-target="list">
+  <section>
     <%= render 'partials/couches', couches: @couches %>
   </section>
 </div>

--- a/app/views/couches/index.json.jbuilder
+++ b/app/views/couches/index.json.jbuilder
@@ -1,1 +1,0 @@
-json.inserted_list render(partial: 'couches/list', formats: :html, locals: { couches: @couches })

--- a/app/views/partials/_couch.html.erb
+++ b/app/views/partials/_couch.html.erb
@@ -2,11 +2,15 @@
   <li class="couches__list-item couch-card">
     <article class="couches__list-article">
       <%= link_to couch_path(couch) do %>
-        <%= cl_image_tag couch.user.photo.key, class: 'couches__image' %>
+        <% if Rails.env.production? %>
+          <%= cl_image_tag couch.user.photo.key, class: 'couches__image' %>
+        <% else %>
+          <%= image_tag couch.user.photo.url, class: 'couches__image' %>
+        <% end %>
       <% end %>
       <div class="couches__content">
         <ul class="couches__features features">
-          <% couch.user.characteristics.each  do |characteristic| %>
+          <% couch.user.characteristics.each do |characteristic| %>
             <li><%= characteristic.name %></li>
           <% end %>
         </ul>

--- a/app/views/partials/_couches.html.erb
+++ b/app/views/partials/_couches.html.erb
@@ -1,5 +1,5 @@
-<div data-characteristics-filter-target="couches">
-  <ul class="couches__list" data-characteristics-filter-target="couches">
+<div>
+  <ul class="couches__list">
     <% couches.each do |couch| %>
       <%= render 'partials/couch', couch: couch %>
     <% end %>

--- a/lib/tasks/populate.rake
+++ b/lib/tasks/populate.rake
@@ -34,7 +34,7 @@ namespace :dev do
     couch.capacity = rand(1..5)
     couch.save!
 
-      Rails.logger.debug("Couch capacity: #{couch.capacity}")
+    Rails.logger.debug("Couch capacity: #{couch.capacity}")
 
     facilities = Facility.all.sample(3)
     facilities.each do |facility|

--- a/lib/tasks/populate.rake
+++ b/lib/tasks/populate.rake
@@ -21,7 +21,7 @@ namespace :dev do
 
     Rails.logger.info 'Create 30 randomized users'
     30.times do
-      new_user = FactoryBot.create(:user, :with_couch, :skip_validation)
+      new_user = FactoryBot.create(:user, :with_couch)
       Rails.logger.info "Created user with address: #{new_user.address}"
     end
   end

--- a/test/schemas/messages_endpoint_test.rb
+++ b/test/schemas/messages_endpoint_test.rb
@@ -28,7 +28,7 @@ class MessagesEndpointTest < ApiEndpointTest
   end
 
   test 'GET /messages for non-existent chat' do
-    get "/api/v1/chats/999/messages", headers: @headers
+    get '/api/v1/chats/999/messages', headers: @headers
     assert_response :not_found
 
     assert_match_openapi_doc

--- a/test/schemas/reviews_endpoint_test.rb
+++ b/test/schemas/reviews_endpoint_test.rb
@@ -11,7 +11,6 @@ class ReviewsEndpointTest < ApiEndpointTest
     @booking = FactoryBot.create(:booking, user: @user, couch: @host.couch)
 
     @review = Review.create!(content: 'Great experience', rating: 5, booking: @booking, user: @user, couch: @host.couch)
-
   end
 
   test 'GET /reviews' do
@@ -29,7 +28,7 @@ class ReviewsEndpointTest < ApiEndpointTest
   end
 
   test 'GET /reviews for non-existent chat' do
-    get "/api/v1/users/999/reviews", headers: @headers
+    get '/api/v1/users/999/reviews', headers: @headers
     assert_response :not_found
 
     assert_match_openapi_doc


### PR DESCRIPTION
Issue number: related to #69 

---

### Description

Remove the need to fetch couches using JavaScript. This way, the ruby controller is always the source of truth.
This should help building the map, as it eliminates the need to duplicate the same behaviour (and fetch twice!)

### Checklist

- [x] Code compiles correctly
- [x] All tests passing
- [x] Rubocop passes
