### PR TITLE
fix: do not call mapbox to get address

### DIFF
--- a/app/controllers/couches_controller.rb
+++ b/app/controllers/couches_controller.rb
@@ -22,7 +22,7 @@ class CouchesController < ApplicationController
     @reviews = Review.where(couch_id: params[:id])
     @review_average = @reviews.average(:rating).to_f
     @chat = Chat.find_by(user_sender_id: @host.id, user_receiver_id: current_user.id) ||
-            Chat.find_by(user_sender_id: current_user.id, user_receiver_id: @host.id)
+      Chat.find_by(user_sender_id: current_user.id, user_receiver_id: @host.id)
   end
 
   def search_cities
@@ -48,6 +48,8 @@ class CouchesController < ApplicationController
       {
         fuzzy: "#{couch.user.zipcode}, #{couch.user.city}, #{couch.user.country}",
         id: couch.id,
+        lng: couch.user.longitude,
+        lat: couch.user.latitude,
         info_popup: {
           data: {
             first_name: couch.user.first_name,


### PR DESCRIPTION
### Description

Currently we're calling Mapbox for every point in the map. Let's just obscure the latitude and longitude that's already saved, to save on HTTP calls
