### PR TITLE
change email to couches user not bookings user

### DIFF
--- a/app/jobs/bookings_job.rb
+++ b/app/jobs/bookings_job.rb
@@ -84,7 +84,7 @@ class BookingsJob < ApplicationJob
           message: booking.message,
           booking_url: Rails.application.routes.url_helpers.booking_url(booking)
         },
-        to: [{ email: booking.user.email }]
+        to: [{ email: booking.couch.user.email }]
       )
       begin
         api_instance.send_transac_email(send_smtp_email)

--- a/test/jobs/bookings_job_test.rb
+++ b/test/jobs/bookings_job_test.rb
@@ -29,7 +29,7 @@ class BookingsJobTest < ActiveJob::TestCase
 
     @brevo_mock.expect(:send_transac_email, smtp_email_response) do |send_smtp_email|
       send_smtp_email.is_a?(SibApiV3Sdk::SendSmtpEmail) &&
-        send_smtp_email.to.first[:email] == future_booking.user.email &&
+        send_smtp_email.to.first[:email] == future_booking.couch.user.email &&
         send_smtp_email.params[:guest_first_name] == future_booking.user.first_name &&
         send_smtp_email.params[:host_first_name] == future_booking.couch.user.first_name &&
         send_smtp_email.params[:message] == future_booking.message &&


### PR DESCRIPTION
### Description

Fix: send email to bookings couch, not the user who made the booking.