### PR TITLE
fix: randomize latitude and longitude in rails

### DIFF
--- a/app/controllers/concerns/couches_concern.rb
+++ b/app/controllers/concerns/couches_concern.rb
@@ -60,4 +60,36 @@ module CouchesConcern
 
     @shuffled_couches = @shuffled_couches.joins(:user).where(user: offers_conditions)
   end
+
+  def get_user_photo(user)
+    user.photo.attached? ? url_for(user.photo) : nil
+  end
+
+  def randomly_haze(coord)
+    coord + rand(-0.011..0.011)
+  end
+
+  def couch_to_marker(couch)
+    return unless couch.user.geocoded?
+
+    hazy_lng = randomly_haze(couch.user.longitude)
+    hazy_lat = randomly_haze(couch.user.latitude)
+
+    {
+      fuzzy: "#{couch.user.zipcode}, #{couch.user.city}, #{couch.user.country}",
+      id: couch.id,
+      lng: hazy_lng,
+      lat: hazy_lat,
+      info_popup: {
+        data: {
+          first_name: couch.user.first_name,
+          last_name: couch.user.last_name,
+          # rating: couch.rating,
+          photo: get_user_photo(couch.user),
+          pronouns: couch.user.pronouns
+        }
+      }
+    }
+  end
+
 end

--- a/app/controllers/couches_controller.rb
+++ b/app/controllers/couches_controller.rb
@@ -41,26 +41,6 @@ class CouchesController < ApplicationController
 
   private
 
-  def couch_to_marker(couch)
-    return unless couch.user.geocoded?
-
-    {
-      fuzzy: "#{couch.user.zipcode}, #{couch.user.city}, #{couch.user.country}",
-      id: couch.id,
-      lng: couch.user.longitude,
-      lat: couch.user.latitude,
-      info_popup: {
-        data: {
-          first_name: couch.user.first_name,
-          last_name: couch.user.last_name,
-          # rating: couch.rating,
-          photo: couch.user.photo.attached? ? url_for(couch.user.photo) : nil,
-          pronouns: couch.user.pronouns
-        }
-      }
-    }
-  end
-
   def generate_markers(couches)
     @markers = []
     couches.find_in_batches(batch_size: 100) do |batch|

--- a/app/javascript/controllers/map_controller.js
+++ b/app/javascript/controllers/map_controller.js
@@ -67,18 +67,9 @@ export default class extends Controller {
 		})
 	}
 
-	obscureCoordinates(lng, lat) {
-		const random = Math.random() / 250
-		// Randomly add or subtract the random value to the coordinates to obscure the location
-		const newLng = Math.random() > 0.5 ? lng + random : lng - random
-		const newLat = Math.random() > 0.5 ? lat + random : lat - random
-
-		return [newLng, newLat]
-	}
-
 	addFuzzyMarkersToMap(markers) {
 		markers.forEach((marker) => {
-			const coordinates = this.obscureCoordinates(marker.lng, marker.lat)
+			const coordinates = [marker.lng, marker.lat]
 			const geometry = {
 				type: 'Point',
 				coordinates: coordinates

--- a/test/controllers/concerns/couches_concern_test.rb
+++ b/test/controllers/concerns/couches_concern_test.rb
@@ -348,6 +348,31 @@ class CouchesConcernTest < ActiveSupport::TestCase
     assert_not_same @couches, first_page
   end
 
+  test 'should haze coordinate' do
+    original_latitude = 52.516112
+
+    # Test the haze function
+    hazy_latitude = randomly_haze(original_latitude)
+    assert_not_equal original_latitude, hazy_latitude
+
+    hazy_latitude2 = randomly_haze(original_latitude)
+    assert_not_equal hazy_latitude, hazy_latitude2
+  end
+
+  test 'should generate fuzzy marker for couch' do
+    user = FactoryBot.create(:user, :offers_couch)
+
+    # Stub :url_for to return a string, since we don't need to test it
+    stub(:get_user_photo, '') do
+      marker = couch_to_marker(user.couch)
+
+      assert_not_nil marker
+      assert_equal user.couch.id, marker[:id]
+      assert_not_equal user.longitude, marker[:lng]
+      assert_not_equal user.latitude, marker[:lat]
+    end
+  end
+
   private
 
   def setup_with_pagination

--- a/test/integration/controllers/couches_controller_test.rb
+++ b/test/integration/controllers/couches_controller_test.rb
@@ -54,8 +54,8 @@ class CouchesControllerTest < ActionDispatch::IntegrationTest
       assert_not_nil markers[0][:fuzzy]
       assert_includes markers[0][:fuzzy], marker_user.zipcode
       assert_equal marker_couch.id, marker1[:id]
-      assert_equal marker_user.longitude, marker1[:lng]
-      assert_equal marker_user.latitude, marker1[:lat]
+      assert_not_nil marker1[:lng]
+      assert_not_nil marker1[:lat]
       assert_not_nil marker1[:info_popup]
     end
   end


### PR DESCRIPTION
Issue number: resolves #69 and [this feedback](https://quouch.slack.com/archives/C068C8ES6NP/p1728293460653209)
---

### Description

Based on user feedback, make the exact address even more obscured.
All the points in this screenshot have the exact same coordinates, and none of the points are actually in that coordinate.

<img width="300" alt="Screenshot 2024-10-08 at 10 33 26" src="https://github.com/user-attachments/assets/ad13461b-addb-4799-89e4-dbb69365fdf9">


### Checklist

- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Rubocop passes
