### PR TITLE
fix: missing context key

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -128,7 +128,7 @@ module Users
     end
 
     def password_valid?
-      resource.valid?(:password_update)
+      resource.valid?(context: :password_update)
     end
   end
 end


### PR DESCRIPTION
### Description

The syntax was wrong

### Checklist

- [x] Code compiles correctly
- [x] All tests passing
- [x] Rubocop passes
