### PR TITLE
add statement to only show chat to user or sender

### DIFF
--- a/app/controllers/chats_controller.rb
+++ b/app/controllers/chats_controller.rb
@@ -11,6 +11,8 @@ class ChatsController < ApplicationController
   end
 
   def show
+    redirect_to chats_path if @chat.user_sender != current_user && @chat.user_receiver != current_user
+
     @chats = current_user.chats.includes(user_receiver: [{ photo_attachment: :blob }]).order('messages.created_at DESC')
     @other_user = @chat.other_user(current_user)
     @receiver = User.find_by(id: @chat.user_receiver_id)

--- a/test/integration/controllers/chats_controller_test.rb
+++ b/test/integration/controllers/chats_controller_test.rb
@@ -1,0 +1,24 @@
+require 'test_helper'
+
+class ChatsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @user = FactoryBot.create(:user, :for_test, :with_couch)
+    @host = FactoryBot.create(:user, :for_test, :offers_couch)
+    @chat = Chat.create(user_sender: @user, user_receiver: @host)
+    @unaffiliated_chat = Chat.create(user_sender: @host,
+                                     user_receiver: FactoryBot.create(:user,
+                                                                      :for_test, :offers_couch))
+    sign_in_as @user
+  end
+
+  test 'should see chat page' do
+    get chat_url(@chat)
+
+    assert_response :success
+  end
+
+  test 'should not see unaffiliated chat page' do
+    get chat_url(@unaffiliated_chat)
+    assert_redirected_to chats_path
+  end
+end


### PR DESCRIPTION
Issue number: resolves #

---

### Description

Add conditional to chats show to only display chat to either sender or receiver.

### Checklist

- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Rubocop passes
- [ ] Extended the README / documentation, if necessary
